### PR TITLE
feat: Phoenix LiveView owner dashboard (item 10)

### DIFF
--- a/docs/work-items/06-orchestrator.md
+++ b/docs/work-items/06-orchestrator.md
@@ -1,8 +1,8 @@
 # 06 — Roundtable.Orchestrator
 
-**Status:** `blocked` (needs 01–05)
-**Assigned:** unassigned
-**Branch:** `feat/orchestrator`
+**Status:** `ready-for-review`
+**Assigned:** Claude IC
+**Branch:** `feat/orchestrator-loop`
 
 ## Scope
 

--- a/docs/work-items/07-cli-entrypoint.md
+++ b/docs/work-items/07-cli-entrypoint.md
@@ -1,8 +1,8 @@
 # 07 — Roundtable.CLI
 
-**Status:** `blocked` (needs 06)
-**Assigned:** unassigned
-**Branch:** `feat/cli-entrypoint`
+**Status:** `ready-for-review`
+**Assigned:** Claude IC
+**Branch:** `feat/orchestrator-loop`
 
 ## Scope
 

--- a/docs/work-items/10-web-dashboard.md
+++ b/docs/work-items/10-web-dashboard.md
@@ -1,0 +1,61 @@
+# 10 — Web Dashboard (Phoenix LiveView)
+
+**Status:** `ready-for-review`
+**Assigned:** Claude IC
+**Branch:** `feat/web-dashboard`
+
+## Scope
+
+Phoenix LiveView single-page dashboard for the repo owner.
+
+### Read path (no orchestrator required)
+
+- Lists all GitHub Issues labelled `roundtable` with title, satisfaction state, label chips, comment count
+- Colour-coded by satisfaction: green (satisfied), amber (conditional), red (needs evidence), grey (unknown)
+- Auto-polls every 30s via LiveView `handle_info(:poll, ...)`
+
+### Write path (requires items 06/07)
+
+- **Inject question** — text area → creates GitHub Issue with `roundtable` + `needs-more-evidence` labels
+- **Trigger round** — fires `Roundtable.CLI.start_discussion/2` in a background `Task`; streams events back to UI via `on_event` callback → `send(lv_pid, ...)`
+
+## Environment variables
+
+| Var | Default | Description |
+|---|---|---|
+| `ROUNDTABLE_REPO` | `""` | GitHub repo slug (`owner/repo`) |
+| `ROUNDTABLE_BRIEF` | `docs/design/BRIEF.md` | Path to BRIEF.md |
+| `PORT` | `4000` | HTTP listen port |
+| `SECRET_KEY_BASE` | dev default | Phoenix session secret (required in prod) |
+| `ROUNDTABLE_WEB` | `"true"` in dev/prod | Set `"false"` to disable web in CLI-only mode |
+
+## Running
+
+```bash
+# In nix devShell or with Elixir installed:
+ROUNDTABLE_REPO=owner/repo mix run --no-halt
+
+# Or via flake app:
+ROUNDTABLE_REPO=owner/repo roundtable-web
+```
+
+## Architecture
+
+```
+Browser ←→ Phoenix LiveView (WebSocket)
+              ↓ on_mount
+          RoundtableWeb.DiscussionLive
+              ↓ get_discussion_state/1   ← polls gh issue list
+          Roundtable.CLI
+              ↓ inject_question/3        ← gh issue create
+              ↓ start_discussion/2       ← Orchestrator.run/3
+          Roundtable.Orchestrator
+```
+
+## What is NOT in v1
+
+- Authentication / access control (the dashboard is localhost-only by default)
+- Question dependency graph view
+- Agent participation tracking chart (load-balancing metric from Q17)
+- Binary execution gate buttons (merge PR, proceed to next work item)
+- DECISION.md / ATTRIBUTION.md edit surface

--- a/roundtable/config/config.exs
+++ b/roundtable/config/config.exs
@@ -1,0 +1,14 @@
+import Config
+
+config :roundtable, RoundtableWeb.Endpoint,
+  url: [host: "localhost"],
+  secret_key_base: System.get_env("SECRET_KEY_BASE") ||
+    "roundtable_dev_secret_do_not_use_in_production_replace_with_mix_phx_gen_secret",
+  render_errors: [formats: [html: RoundtableWeb.ErrorHTML]],
+  pubsub_server: Roundtable.PubSub,
+  live_view: [signing_salt: "roundtable_lv_salt"]
+
+config :roundtable, RoundtableWeb.Endpoint,
+  adapter: Bandit.PhoenixAdapter
+
+import_config "#{config_env()}.exs"

--- a/roundtable/config/dev.exs
+++ b/roundtable/config/dev.exs
@@ -1,0 +1,11 @@
+import Config
+
+config :roundtable, RoundtableWeb.Endpoint,
+  http: [port: 4000],
+  debug_errors: true,
+  code_reloader: false,
+  check_origin: false,
+  watchers: []
+
+config :logger, :console, format: "[$level] $message\n"
+config :phoenix, :stacktrace_depth, 20

--- a/roundtable/config/runtime.exs
+++ b/roundtable/config/runtime.exs
@@ -1,0 +1,14 @@
+import Config
+
+if config_env() == :prod do
+  secret_key_base =
+    System.get_env("SECRET_KEY_BASE") ||
+      raise "SECRET_KEY_BASE env var required in production"
+
+  port = String.to_integer(System.get_env("PORT") || "4000")
+
+  config :roundtable, RoundtableWeb.Endpoint,
+    http: [port: port],
+    secret_key_base: secret_key_base,
+    url: [host: System.get_env("HOST") || "localhost", port: port]
+end

--- a/roundtable/config/test.exs
+++ b/roundtable/config/test.exs
@@ -1,0 +1,7 @@
+import Config
+
+config :roundtable, RoundtableWeb.Endpoint,
+  http: [port: 4002],
+  server: false
+
+config :logger, level: :warning

--- a/roundtable/config/test.exs
+++ b/roundtable/config/test.exs
@@ -4,4 +4,5 @@ config :roundtable, RoundtableWeb.Endpoint,
   http: [port: 4002],
   server: false
 
+config :roundtable, web_enabled: false
 config :logger, level: :warning

--- a/roundtable/lib/roundtable/application.ex
+++ b/roundtable/lib/roundtable/application.ex
@@ -21,13 +21,7 @@ defmodule Roundtable.Application do
   end
 
   defp web_enabled? do
-    Mix.env() in [:dev, :prod] or System.get_env("ROUNDTABLE_WEB") == "true"
-  end
-
-  defp web_port do
-    case System.get_env("PORT") do
-      nil -> 4000
-      p -> String.to_integer(p)
-    end
+    Application.get_env(:roundtable, :web_enabled, true) or
+      System.get_env("ROUNDTABLE_WEB") == "true"
   end
 end

--- a/roundtable/lib/roundtable/application.ex
+++ b/roundtable/lib/roundtable/application.ex
@@ -7,14 +7,27 @@ defmodule Roundtable.Application do
 
   @impl true
   def start(_type, _args) do
-    children = [
-      # Starts a worker by calling: Roundtable.Worker.start_link(arg)
-      # {Roundtable.Worker, arg}
-    ]
+    children =
+      [
+        {Phoenix.PubSub, name: Roundtable.PubSub},
+        if web_enabled?() do
+          RoundtableWeb.Endpoint
+        end
+      ]
+      |> Enum.reject(&is_nil/1)
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Roundtable.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp web_enabled? do
+    Mix.env() in [:dev, :prod] or System.get_env("ROUNDTABLE_WEB") == "true"
+  end
+
+  defp web_port do
+    case System.get_env("PORT") do
+      nil -> 4000
+      p -> String.to_integer(p)
+    end
   end
 end

--- a/roundtable/lib/roundtable_web/endpoint.ex
+++ b/roundtable/lib/roundtable_web/endpoint.ex
@@ -1,0 +1,19 @@
+defmodule RoundtableWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :roundtable
+
+  socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
+
+  plug Plug.Static,
+    at: "/",
+    from: :roundtable,
+    gzip: false,
+    only: ~w(assets fonts images favicon.ico robots.txt)
+
+  plug Plug.RequestId
+  plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
+  plug Plug.Parsers, parsers: [:urlencoded, :multipart, :json], json_decoder: Jason
+  plug Plug.MethodOverride
+  plug Plug.Head
+  plug Plug.Session, @session_options
+  plug RoundtableWeb.Router
+end

--- a/roundtable/lib/roundtable_web/endpoint.ex
+++ b/roundtable/lib/roundtable_web/endpoint.ex
@@ -1,6 +1,12 @@
 defmodule RoundtableWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :roundtable
 
+  @session_options [
+    store: :cookie,
+    key: "_roundtable_key",
+    signing_salt: "roundtable_session_salt"
+  ]
+
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
 
   plug Plug.Static,

--- a/roundtable/lib/roundtable_web/layouts.ex
+++ b/roundtable/lib/roundtable_web/layouts.ex
@@ -1,0 +1,32 @@
+defmodule RoundtableWeb.Layouts do
+  use Phoenix.Component
+
+  def root(assigns) do
+    ~H"""
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Roundtable</title>
+        <style>
+          *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+          body { font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', monospace;
+                 background: #0d1117; color: #c9d1d9; min-height: 100vh; }
+          a { color: #58a6ff; }
+        </style>
+        {@inner_content}
+      </head>
+      <body>
+        {@inner_content}
+      </body>
+    </html>
+    """
+  end
+
+  def app(assigns) do
+    ~H"""
+    {@inner_content}
+    """
+  end
+end

--- a/roundtable/lib/roundtable_web/live/discussion_live.ex
+++ b/roundtable/lib/roundtable_web/live/discussion_live.ex
@@ -43,6 +43,12 @@ defmodule RoundtableWeb.DiscussionLive do
   end
 
   @impl true
+  def handle_info({:roundtable_event, {:round_complete, _n} = event}, socket) do
+    msg = format_event(event)
+    {:noreply, assign(socket, running: false, flash_msg: msg)}
+  end
+
+  @impl true
   def handle_info({:roundtable_event, event}, socket) do
     msg = format_event(event)
     {:noreply, assign(socket, :flash_msg, msg)}
@@ -93,13 +99,8 @@ defmodule RoundtableWeb.DiscussionLive do
         send(lv_pid, {:roundtable_event, {:round_complete, length(questions)}})
       end)
 
-      {:noreply, assign(socket, :running, true, :flash_msg, "Round started…")}
+      {:noreply, assign(socket, running: true, flash_msg: "Round started…")}
     end
-  end
-
-  @impl true
-  def handle_event("set_inject_text", %{"value" => v}, socket) do
-    {:noreply, assign(socket, :inject_text, v)}
   end
 
   @impl true
@@ -144,13 +145,11 @@ defmodule RoundtableWeb.DiscussionLive do
         <form phx-submit="inject_question" style="display: flex; gap: 0.5rem; align-items: flex-start;">
           <textarea
             name="text"
-            value={@inject_text}
-            phx-keyup="set_inject_text"
             placeholder="New question text…"
             rows="3"
             style="flex: 1; background: #161b22; border: 1px solid #30363d; border-radius: 6px;
                    color: #c9d1d9; padding: 0.5rem 0.75rem; font-family: inherit; font-size: 0.9rem; resize: vertical;"
-          />
+          >{@inject_text}</textarea>
           <button type="submit" style={btn_style(:primary)}>Add</button>
         </form>
       </section>

--- a/roundtable/lib/roundtable_web/live/discussion_live.ex
+++ b/roundtable/lib/roundtable_web/live/discussion_live.ex
@@ -1,0 +1,276 @@
+defmodule RoundtableWeb.DiscussionLive do
+  @moduledoc """
+  Owner dashboard for the roundtable discussion.
+
+  Reads `ROUNDTABLE_REPO` env var for the GitHub repo slug.
+  Polls GitHub Issues every 30s to show current discussion state.
+
+  Owner actions:
+  - Inject new question → creates a GitHub Issue
+  - Trigger next round → starts the orchestrator for unsatisfied questions
+  - View each question's satisfaction state and comment thread
+  """
+
+  use Phoenix.LiveView
+
+  alias Roundtable.CLI
+
+  @poll_interval_ms 30_000
+
+  @impl true
+  def mount(_params, _session, socket) do
+    repo = System.get_env("ROUNDTABLE_REPO", "")
+    brief_path = System.get_env("ROUNDTABLE_BRIEF", "docs/design/BRIEF.md")
+
+    if connected?(socket), do: schedule_poll()
+
+    socket =
+      socket
+      |> assign(:repo, repo)
+      |> assign(:brief_path, brief_path)
+      |> assign(:inject_text, "")
+      |> assign(:running, false)
+      |> assign(:flash_msg, nil)
+      |> load_state(repo)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_info(:poll, socket) do
+    schedule_poll()
+    {:noreply, load_state(socket, socket.assigns.repo)}
+  end
+
+  @impl true
+  def handle_info({:roundtable_event, event}, socket) do
+    msg = format_event(event)
+    {:noreply, assign(socket, :flash_msg, msg)}
+  end
+
+  @impl true
+  def handle_event("inject_question", %{"text" => text}, socket) when byte_size(text) > 0 do
+    repo = socket.assigns.repo
+
+    case CLI.inject_question(repo, text) do
+      {:ok, number} ->
+        socket =
+          socket
+          |> assign(:inject_text, "")
+          |> assign(:flash_msg, "Created issue ##{number}")
+          |> load_state(repo)
+
+        {:noreply, socket}
+
+      {:error, reason} ->
+        {:noreply, assign(socket, :flash_msg, "Error: #{inspect(reason)}")}
+    end
+  end
+
+  def handle_event("inject_question", _params, socket) do
+    {:noreply, assign(socket, :flash_msg, "Question text cannot be empty.")}
+  end
+
+  @impl true
+  def handle_event("trigger_round", _params, socket) do
+    if socket.assigns.running do
+      {:noreply, assign(socket, :flash_msg, "A round is already running.")}
+    else
+      repo = socket.assigns.repo
+      brief_path = socket.assigns.brief_path
+      lv_pid = self()
+
+      Task.start(fn ->
+        questions = open_questions(socket.assigns.questions)
+
+        CLI.start_discussion(brief_path,
+          repo: repo,
+          on_event: fn event ->
+            send(lv_pid, {:roundtable_event, event})
+          end
+        )
+
+        send(lv_pid, {:roundtable_event, {:round_complete, length(questions)}})
+      end)
+
+      {:noreply, assign(socket, :running, true, :flash_msg, "Round started…")}
+    end
+  end
+
+  @impl true
+  def handle_event("set_inject_text", %{"value" => v}, socket) do
+    {:noreply, assign(socket, :inject_text, v)}
+  end
+
+  @impl true
+  def handle_event("dismiss_flash", _params, socket) do
+    {:noreply, assign(socket, :flash_msg, nil)}
+  end
+
+  # ----- render -----
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div style="max-width: 900px; margin: 0 auto; padding: 2rem 1rem;">
+      <header style="margin-bottom: 2rem;">
+        <h1 style="font-size: 1.4rem; color: #f0f6fc; margin-bottom: 0.25rem;">
+          Roundtable
+        </h1>
+        <p style="color: #8b949e; font-size: 0.85rem;">
+          {@repo}
+          <span :if={@running} style="color: #d29922; margin-left: 1rem;">● running</span>
+        </p>
+      </header>
+
+      <.flash_banner :if={@flash_msg} msg={@flash_msg} />
+
+      <section style="margin-bottom: 2rem;">
+        <h2 style="font-size: 1rem; color: #8b949e; margin-bottom: 1rem; text-transform: uppercase; letter-spacing: 0.05em;">
+          Questions
+        </h2>
+
+        <div :if={map_size(@questions) == 0} style="color: #8b949e; font-style: italic;">
+          No roundtable issues found. Create one below or push a BRIEF.md.
+        </div>
+
+        <.question_card :for={{number, q} <- Enum.sort(@questions)} number={number} q={q} />
+      </section>
+
+      <section style="margin-bottom: 2rem;">
+        <h2 style="font-size: 1rem; color: #8b949e; margin-bottom: 1rem; text-transform: uppercase; letter-spacing: 0.05em;">
+          Inject Question
+        </h2>
+        <form phx-submit="inject_question" style="display: flex; gap: 0.5rem; align-items: flex-start;">
+          <textarea
+            name="text"
+            value={@inject_text}
+            phx-keyup="set_inject_text"
+            placeholder="New question text…"
+            rows="3"
+            style="flex: 1; background: #161b22; border: 1px solid #30363d; border-radius: 6px;
+                   color: #c9d1d9; padding: 0.5rem 0.75rem; font-family: inherit; font-size: 0.9rem; resize: vertical;"
+          />
+          <button type="submit" style={btn_style(:primary)}>Add</button>
+        </form>
+      </section>
+
+      <section>
+        <h2 style="font-size: 1rem; color: #8b949e; margin-bottom: 1rem; text-transform: uppercase; letter-spacing: 0.05em;">
+          Controls
+        </h2>
+        <div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
+          <button phx-click="trigger_round" disabled={@running} style={btn_style(:action)}>
+            <%= if @running, do: "Running…", else: "Trigger round" %>
+          </button>
+        </div>
+      </section>
+    </div>
+    """
+  end
+
+  # ----- components -----
+
+  defp flash_banner(assigns) do
+    ~H"""
+    <div style="background: #1c2128; border: 1px solid #30363d; border-radius: 6px;
+                padding: 0.75rem 1rem; margin-bottom: 1.5rem; display: flex;
+                justify-content: space-between; align-items: center;">
+      <span style="color: #c9d1d9; font-size: 0.9rem;">{@msg}</span>
+      <button phx-click="dismiss_flash" style="background: none; border: none; color: #8b949e;
+                cursor: pointer; font-size: 1.1rem; line-height: 1;">×</button>
+    </div>
+    """
+  end
+
+  defp question_card(assigns) do
+    ~H"""
+    <div style={"border: 1px solid #{border_color(@q.satisfaction)}; border-radius: 6px;
+                 padding: 1rem; margin-bottom: 0.75rem; background: #161b22;"}>
+      <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 0.5rem;">
+        <a href={@q.url} target="_blank" style="font-weight: 600; font-size: 0.95rem; color: #f0f6fc;">
+          #{@number} {@q.title}
+        </a>
+        <.satisfaction_badge sat={@q.satisfaction} />
+      </div>
+      <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.5rem;">
+        <.label_chip :for={l <- @q.labels} label={l} />
+      </div>
+      <div style="font-size: 0.8rem; color: #8b949e; margin-top: 0.5rem;">
+        {@q.comment_count} comment(s) ·
+        <span style={"color: #{if @q.state == :open, do: "#3fb950", else: "#8b949e"};"}>
+          {if @q.state == :open, do: "open", else: "closed"}
+        </span>
+      </div>
+    </div>
+    """
+  end
+
+  defp satisfaction_badge(assigns) do
+    {text, color} =
+      case assigns.sat do
+        :satisfied -> {"✓ satisfied", "#3fb950"}
+        :satisfied_conditional -> {"~ conditional", "#d29922"}
+        :needs_more_evidence -> {"○ needs evidence", "#f78166"}
+        _ -> {"– unknown", "#8b949e"}
+      end
+
+    assigns = assign(assigns, text: text, color: color)
+
+    ~H"""
+    <span style={"font-size: 0.75rem; color: #{@color}; font-weight: 600;"}>{@text}</span>
+    """
+  end
+
+  defp label_chip(assigns) do
+    ~H"""
+    <span style="background: #21262d; border: 1px solid #30363d; border-radius: 12px;
+                 padding: 0.1rem 0.6rem; font-size: 0.75rem; color: #8b949e;">
+      {@label}
+    </span>
+    """
+  end
+
+  # ----- helpers -----
+
+  defp load_state(socket, "") do
+    assign(socket, :questions, %{})
+  end
+
+  defp load_state(socket, repo) do
+    case CLI.get_discussion_state(repo) do
+      {:ok, state} -> assign(socket, :questions, state)
+      {:error, _} -> assign(socket, :questions, %{})
+    end
+  end
+
+  defp open_questions(questions) do
+    questions
+    |> Enum.filter(fn {_, q} -> q.state == :open end)
+    |> Enum.map(fn {number, q} -> %{id: q.title, issue_number: number, state: :open} end)
+  end
+
+  defp schedule_poll, do: Process.send_after(self(), :poll, @poll_interval_ms)
+
+  defp border_color(:satisfied), do: "#238636"
+  defp border_color(:satisfied_conditional), do: "#9e6a03"
+  defp border_color(:needs_more_evidence), do: "#da3633"
+  defp border_color(_), do: "#30363d"
+
+  defp btn_style(:primary) do
+    "background: #238636; color: #fff; border: none; border-radius: 6px; padding: 0.5rem 1rem;
+     cursor: pointer; font-family: inherit; font-size: 0.9rem;"
+  end
+
+  defp btn_style(:action) do
+    "background: #1f6feb; color: #fff; border: none; border-radius: 6px; padding: 0.5rem 1rem;
+     cursor: pointer; font-family: inherit; font-size: 0.9rem;"
+  end
+
+  defp format_event({:round_start, id, n}), do: "#{id}: round #{n} started"
+  defp format_event({:agent_done, agent, _issue}), do: "#{agent} posted"
+  defp format_event({:question_satisfied, id, n}), do: "#{id} satisfied after #{n} round(s)"
+  defp format_event({:question_max_rounds, id}), do: "#{id} needs human review"
+  defp format_event({:round_complete, n}), do: "Round complete — #{n} question(s) processed"
+  defp format_event(_), do: nil
+end

--- a/roundtable/lib/roundtable_web/router.ex
+++ b/roundtable/lib/roundtable_web/router.ex
@@ -1,0 +1,19 @@
+defmodule RoundtableWeb.Router do
+  use Phoenix.Router
+  import Phoenix.LiveView.Router
+
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_live_flash
+    plug :put_root_layout, html: {RoundtableWeb.Layouts, :root}
+    plug :protect_from_forgery
+    plug :put_secure_browser_headers
+  end
+
+  scope "/", RoundtableWeb do
+    pipe_through :browser
+
+    live "/", DiscussionLive
+  end
+end

--- a/roundtable/mix.exs
+++ b/roundtable/mix.exs
@@ -11,7 +11,6 @@ defmodule Roundtable.MixProject do
     ]
   end
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger],
@@ -19,10 +18,16 @@ defmodule Roundtable.MixProject do
     ]
   end
 
-  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:jido, "~> 2.0"}
+      {:jido, "~> 2.0"},
+      # Web dashboard (item 10)
+      {:phoenix, "~> 1.7"},
+      {:phoenix_live_view, "~> 1.0"},
+      {:phoenix_html, "~> 4.0"},
+      {:phoenix_pubsub, "~> 2.1"},
+      {:bandit, "~> 1.0"},
+      {:jason, "~> 1.4"}
     ]
   end
 end


### PR DESCRIPTION
## Summary

Adds a Phoenix LiveView single-page dashboard for the roundtable owner.

**Read path** (works immediately, no orchestrator needed):
- Lists all GitHub Issues labelled `roundtable`
- Satisfaction state colour-coded: ✓ green / ~ amber / ○ red / – grey
- Auto-polls every 30s

**Write path** (requires items 06/07 from `feat/orchestrator-loop`):
- **Inject Question** — creates a GitHub Issue with `roundtable` + `needs-more-evidence` labels
- **Trigger Round** — runs `Roundtable.CLI.start_discussion/2` in a background Task; streams events to UI

## Running

```bash
ROUNDTABLE_REPO=owner/repo mix run --no-halt
# then open http://localhost:4000
```

## Dependencies

- `feat/orchestrator-loop` must merge first (this PR is based on it)
- Env: `ROUNDTABLE_REPO`, `ROUNDTABLE_BRIEF`, `PORT`, `SECRET_KEY_BASE`

## Not in v1

- Auth / access control (localhost-only by default)
- Agent participation tracking chart
- Binary execution gate buttons
- DECISION.md edit surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/agent-roundtable/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
