### PR TITLE
feat: Roundtable.RoundRun persisted state (item 11)

### DIFF
--- a/roundtable/config/test.exs
+++ b/roundtable/config/test.exs
@@ -5,4 +5,5 @@ config :roundtable, RoundtableWeb.Endpoint,
   server: false
 
 config :roundtable, web_enabled: false
+config :roundtable, state_dir: "/tmp/roundtable_test_state"
 config :logger, level: :warning

--- a/roundtable/lib/roundtable/actions/gh/close_issue.ex
+++ b/roundtable/lib/roundtable/actions/gh/close_issue.ex
@@ -20,8 +20,8 @@ defmodule Roundtable.Actions.Gh.CloseIssue do
     }
 
     opts = []
-    opts = if params[:reason], do: [reason: params[:reason] | opts], else: opts
-    opts = if params[:comment], do: [comment: params[:comment] | opts], else: opts
+    opts = if params[:reason], do: [{:reason, params[:reason]} | opts], else: opts
+    opts = if params[:comment], do: [{:comment, params[:comment]} | opts], else: opts
 
     case Gh.close_issue(params[:number], opts, config) do
       :ok -> {:ok, %{status: "closed"}}

--- a/roundtable/lib/roundtable/application.ex
+++ b/roundtable/lib/roundtable/application.ex
@@ -7,6 +7,8 @@ defmodule Roundtable.Application do
 
   @impl true
   def start(_type, _args) do
+    Roundtable.RoundRun.init()
+
     children =
       [
         {Phoenix.PubSub, name: Roundtable.PubSub},

--- a/roundtable/lib/roundtable/cli.ex
+++ b/roundtable/lib/roundtable/cli.ex
@@ -146,6 +146,8 @@ defmodule Roundtable.CLI do
   """
   @spec inject_question(String.t(), String.t(), keyword()) ::
           {:ok, pos_integer()} | {:error, term()}
+  def inject_question(nil, _question_text, _opts), do: {:error, :no_repo_configured}
+
   def inject_question(repo, question_text, opts \\ []) do
     gh_config = %{repo: repo}
     title = question_text |> String.split("\n") |> List.first() |> String.slice(0, 120)

--- a/roundtable/lib/roundtable/round_run.ex
+++ b/roundtable/lib/roundtable/round_run.ex
@@ -1,0 +1,317 @@
+defmodule Roundtable.RoundRun do
+  @moduledoc """
+  Persisted state for a single question's progress through the orchestrator.
+
+  ## Storage
+
+  - **Hot:** ETS table `:roundtable_round_runs`, keyed by `issue_number`.
+    Call `init/0` once on application start before using any other function.
+  - **Durable:** JSON snapshot flushed to `<state_dir>/round_run_<n>.json`
+    on every `persist/1` call. On restart, `load/1` falls back to the JSON
+    file when the ETS table is cold.
+
+  The state directory defaults to `"state"` but can be overridden via:
+
+      config :roundtable, state_dir: "/tmp/roundtable_state"
+
+  ## Reconciliation
+
+  `reconcile_from_github/2` rebuilds a `RoundRun` from live GitHub data —
+  useful after a crash or when no snapshot exists. It calls
+  `Gh.view_issue/3`, parses comment authorship and satisfaction markers,
+  and infers the current phase from labels.
+  """
+
+  alias Roundtable.Actions.Gh
+  alias Roundtable.Satisfaction
+
+  @table :roundtable_round_runs
+
+  @type phase ::
+          :awaiting_turns
+          | :triage_missing_markers
+          | :consensus_check
+          | :needs_human_input
+          | :closed
+          | :needs_human_review
+
+  @type satisfaction_result ::
+          :satisfied | :satisfied_conditional | :needs_more_evidence
+
+  @type t :: %__MODULE__{
+          issue_number: pos_integer(),
+          phase: phase(),
+          expected_speakers: [atom()],
+          completed_speakers: [atom()],
+          last_comment_ids: [String.t()],
+          satisfaction_map: %{atom() => satisfaction_result()},
+          retry_count: non_neg_integer(),
+          updated_at: DateTime.t()
+        }
+
+  defstruct [
+    :issue_number,
+    :phase,
+    :expected_speakers,
+    :completed_speakers,
+    :last_comment_ids,
+    :satisfaction_map,
+    :retry_count,
+    :updated_at
+  ]
+
+  @doc """
+  Initialise the ETS backing store.
+
+  Idempotent — safe to call multiple times; an existing table is reused.
+  Must be called before `persist/1` or `load/1`.
+  """
+  @spec init() :: :ok
+  def init do
+    case :ets.info(@table) do
+      :undefined ->
+        :ets.new(@table, [:set, :public, :named_table])
+        :ok
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc "Create a fresh `RoundRun` in the `:awaiting_turns` phase."
+  @spec new(pos_integer(), [atom()]) :: t()
+  def new(issue_number, expected_speakers) do
+    %__MODULE__{
+      issue_number: issue_number,
+      phase: :awaiting_turns,
+      expected_speakers: expected_speakers,
+      completed_speakers: [],
+      last_comment_ids: [],
+      satisfaction_map: %{},
+      retry_count: 0,
+      updated_at: DateTime.utc_now()
+    }
+  end
+
+  @doc "Transition to `phase`, stamping `updated_at`."
+  @spec put_phase(t(), phase()) :: t()
+  def put_phase(%__MODULE__{} = run, phase) do
+    %{run | phase: phase, updated_at: DateTime.utc_now()}
+  end
+
+  @doc """
+  Record that `agent` completed their turn with `satisfaction`.
+
+  Pass `nil` for `satisfaction` when the marker hasn't been parsed yet;
+  an existing entry in `satisfaction_map` is preserved.
+  """
+  @spec mark_speaker_done(t(), atom(), satisfaction_result() | nil) :: t()
+  def mark_speaker_done(%__MODULE__{} = run, agent, satisfaction) do
+    completed = Enum.uniq([agent | run.completed_speakers])
+
+    sat_map =
+      if satisfaction,
+        do: Map.put(run.satisfaction_map, agent, satisfaction),
+        else: run.satisfaction_map
+
+    %{run | completed_speakers: completed, satisfaction_map: sat_map, updated_at: DateTime.utc_now()}
+  end
+
+  @doc "Persist to ETS and flush a JSON snapshot to the state directory."
+  @spec persist(t()) :: :ok | {:error, term()}
+  def persist(%__MODULE__{} = run) do
+    :ets.insert(@table, {run.issue_number, run})
+    flush_json(run)
+  end
+
+  @doc """
+  Load from ETS; falls back to the JSON snapshot on disk.
+
+  Returns `{:error, :not_found}` when neither source has data.
+  """
+  @spec load(pos_integer()) :: {:ok, t()} | {:error, :not_found}
+  def load(issue_number) do
+    case :ets.lookup(@table, issue_number) do
+      [{^issue_number, run}] -> {:ok, run}
+      [] -> load_from_json(issue_number)
+    end
+  end
+
+  @doc """
+  Rebuild a `RoundRun` from live GitHub issue data.
+
+  Calls `Gh.view_issue/3` for `issue_number`, then:
+  - parses `completed_speakers` from comment authorship headers
+  - re-parses satisfaction markers from each speaker's most recent comment
+  - infers `phase` from current issue labels and open/closed state
+
+  `gh_config` accepts an `:agents` key to set `expected_speakers`;
+  defaults to `[:codex, :gemini, :claude_ic]`.
+  """
+  @spec reconcile_from_github(pos_integer(), map()) :: {:ok, t()} | {:error, term()}
+  def reconcile_from_github(issue_number, gh_config) do
+    expected = Map.get(gh_config, :agents, [:codex, :gemini, :claude_ic])
+
+    case Gh.view_issue(issue_number, [:comments, :labels, :state], gh_config) do
+      {:error, reason} ->
+        {:error, reason}
+
+      {:ok, issue} ->
+        {:ok, build_from_issue(issue_number, expected, issue)}
+    end
+  end
+
+  @doc false
+  # Public for testing — constructs a RoundRun from a pre-fetched issue map.
+  @spec build_from_issue(pos_integer(), [atom()], map()) :: t()
+  def build_from_issue(issue_number, expected_speakers, issue) do
+    comments = Map.get(issue, "comments", [])
+    labels = extract_label_names(issue)
+
+    {completed, sat_map, comment_ids} = parse_comments(comments)
+    phase = infer_phase(labels, issue)
+
+    %__MODULE__{
+      issue_number: issue_number,
+      phase: phase,
+      expected_speakers: expected_speakers,
+      completed_speakers: completed,
+      last_comment_ids: comment_ids,
+      satisfaction_map: sat_map,
+      retry_count: 0,
+      updated_at: DateTime.utc_now()
+    }
+  end
+
+  # ------------------------------------------------------------------
+  # JSON persistence
+  # ------------------------------------------------------------------
+
+  defp state_dir, do: Application.get_env(:roundtable, :state_dir, "state")
+
+  defp flush_json(%__MODULE__{} = run) do
+    dir = state_dir()
+    File.mkdir_p!(dir)
+    path = Path.join(dir, "round_run_#{run.issue_number}.json")
+
+    data = %{
+      issue_number: run.issue_number,
+      phase: Atom.to_string(run.phase),
+      expected_speakers: Enum.map(run.expected_speakers, &Atom.to_string/1),
+      completed_speakers: Enum.map(run.completed_speakers, &Atom.to_string/1),
+      last_comment_ids: run.last_comment_ids,
+      satisfaction_map:
+        Map.new(run.satisfaction_map, fn {k, v} ->
+          {Atom.to_string(k), Atom.to_string(v)}
+        end),
+      retry_count: run.retry_count,
+      updated_at: DateTime.to_iso8601(run.updated_at)
+    }
+
+    case Jason.encode(data, pretty: true) do
+      {:ok, json} -> File.write(path, json)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp load_from_json(issue_number) do
+    path = Path.join(state_dir(), "round_run_#{issue_number}.json")
+
+    with {:ok, json} <- File.read(path),
+         {:ok, data} <- Jason.decode(json) do
+      run = %__MODULE__{
+        issue_number: data["issue_number"],
+        phase: String.to_existing_atom(data["phase"]),
+        expected_speakers: Enum.map(data["expected_speakers"], &String.to_existing_atom/1),
+        completed_speakers: Enum.map(data["completed_speakers"], &String.to_existing_atom/1),
+        last_comment_ids: data["last_comment_ids"],
+        satisfaction_map:
+          Map.new(data["satisfaction_map"], fn {k, v} ->
+            {String.to_existing_atom(k), String.to_existing_atom(v)}
+          end),
+        retry_count: data["retry_count"],
+        updated_at: parse_datetime(data["updated_at"])
+      }
+
+      {:ok, run}
+    else
+      {:error, :enoent} -> {:error, :not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp parse_datetime(str) do
+    case DateTime.from_iso8601(str) do
+      {:ok, dt, _} -> dt
+      _ -> DateTime.utc_now()
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Comment parsing
+  # ------------------------------------------------------------------
+
+  # Maps the comment header prefix to the agent atom.
+  @agent_headers [
+    {"## Claude IC", :claude_ic},
+    {"## Codex", :codex},
+    {"## Gemini", :gemini}
+  ]
+
+  @doc false
+  def parse_comments(comments) do
+    {completed, sat_map, ids} =
+      Enum.reduce(comments, {[], %{}, []}, fn comment, {comp, sat, ids} ->
+        body = Map.get(comment, "body", "")
+        id = Map.get(comment, "id", "") |> to_string()
+
+        case detect_agent(body) do
+          nil ->
+            {comp, sat, ids}
+
+          agent ->
+            satisfaction = Satisfaction.parse_marker(body)
+            sat = if satisfaction, do: Map.put(sat, agent, label_to_atom(satisfaction)), else: sat
+            {Enum.uniq([agent | comp]), sat, [id | ids]}
+        end
+      end)
+
+    {Enum.reverse(completed), sat_map, Enum.reverse(ids)}
+  end
+
+  defp detect_agent(body) do
+    Enum.find_value(@agent_headers, nil, fn {header, atom} ->
+      if String.starts_with?(body, header), do: atom
+    end)
+  end
+
+  defp label_to_atom("satisfied"), do: :satisfied
+  defp label_to_atom("satisfied-conditional"), do: :satisfied_conditional
+  defp label_to_atom("needs-more-evidence"), do: :needs_more_evidence
+  defp label_to_atom(_), do: nil
+
+  # ------------------------------------------------------------------
+  # Phase inference
+  # ------------------------------------------------------------------
+
+  defp infer_phase(labels, issue) do
+    state = Map.get(issue, "state", "open")
+
+    cond do
+      state == "closed" -> :closed
+      "needs-human-review" in labels -> :needs_human_review
+      "needs-human-input" in labels -> :needs_human_input
+      true -> :awaiting_turns
+    end
+  end
+
+  defp extract_label_names(%{"labels" => labels}) when is_list(labels) do
+    Enum.map(labels, fn
+      %{"name" => name} -> name
+      name when is_binary(name) -> name
+      _ -> ""
+    end)
+  end
+
+  defp extract_label_names(_), do: []
+end

--- a/roundtable/lib/roundtable/satisfaction.ex
+++ b/roundtable/lib/roundtable/satisfaction.ex
@@ -4,8 +4,8 @@ defmodule Roundtable.Satisfaction do
   """
 
   @markers [
-    {"satisfied", "satisfied"},
     {"satisfied-conditional", "satisfied-conditional"},
+    {"satisfied", "satisfied"},
     {"needs more evidence", "needs-more-evidence"}
   ]
 

--- a/roundtable/test/roundtable/round_run_test.exs
+++ b/roundtable/test/roundtable/round_run_test.exs
@@ -1,0 +1,261 @@
+defmodule Roundtable.RoundRunTest do
+  use ExUnit.Case, async: false
+
+  alias Roundtable.RoundRun
+
+  @test_issue 88_001
+
+  setup do
+    RoundRun.init()
+
+    on_exit(fn ->
+      :ets.delete(:roundtable_round_runs, @test_issue)
+      File.rm("/tmp/roundtable_test_state/round_run_#{@test_issue}.json")
+    end)
+
+    :ok
+  end
+
+  # ------------------------------------------------------------------
+  # new/2
+  # ------------------------------------------------------------------
+
+  describe "new/2" do
+    test "creates struct with correct defaults" do
+      run = RoundRun.new(@test_issue, [:codex, :gemini, :claude_ic])
+
+      assert run.issue_number == @test_issue
+      assert run.phase == :awaiting_turns
+      assert run.expected_speakers == [:codex, :gemini, :claude_ic]
+      assert run.completed_speakers == []
+      assert run.satisfaction_map == %{}
+      assert run.retry_count == 0
+      assert %DateTime{} = run.updated_at
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # put_phase/2
+  # ------------------------------------------------------------------
+
+  describe "put_phase/2" do
+    test "transitions phase" do
+      run = RoundRun.new(@test_issue, [:codex])
+      updated = RoundRun.put_phase(run, :consensus_check)
+      assert updated.phase == :consensus_check
+    end
+
+    test "stamps updated_at" do
+      run = RoundRun.new(@test_issue, [:codex])
+      before_dt = run.updated_at
+      # ensure at least 1ms passes
+      Process.sleep(2)
+      updated = RoundRun.put_phase(run, :triage_missing_markers)
+      assert DateTime.compare(updated.updated_at, before_dt) == :gt
+    end
+
+    test "all valid phases round-trip" do
+      phases = [
+        :awaiting_turns,
+        :triage_missing_markers,
+        :consensus_check,
+        :needs_human_input,
+        :closed,
+        :needs_human_review
+      ]
+
+      run = RoundRun.new(@test_issue, [])
+
+      for phase <- phases do
+        assert RoundRun.put_phase(run, phase).phase == phase
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # mark_speaker_done/3
+  # ------------------------------------------------------------------
+
+  describe "mark_speaker_done/3" do
+    test "adds agent to completed_speakers" do
+      run = RoundRun.new(@test_issue, [:codex, :gemini])
+      run = RoundRun.mark_speaker_done(run, :codex, :satisfied)
+
+      assert :codex in run.completed_speakers
+      assert run.satisfaction_map[:codex] == :satisfied
+    end
+
+    test "is idempotent for the same agent" do
+      run = RoundRun.new(@test_issue, [:codex])
+      run = RoundRun.mark_speaker_done(run, :codex, :satisfied)
+      run = RoundRun.mark_speaker_done(run, :codex, :satisfied)
+
+      assert length(run.completed_speakers) == 1
+    end
+
+    test "nil satisfaction preserves existing entry" do
+      run = RoundRun.new(@test_issue, [:codex])
+      run = RoundRun.mark_speaker_done(run, :codex, :satisfied)
+      run = RoundRun.mark_speaker_done(run, :codex, nil)
+
+      assert run.satisfaction_map[:codex] == :satisfied
+    end
+
+    test "records all three satisfaction results" do
+      run = RoundRun.new(@test_issue, [:codex, :gemini, :claude_ic])
+      run = RoundRun.mark_speaker_done(run, :codex, :satisfied)
+      run = RoundRun.mark_speaker_done(run, :gemini, :satisfied_conditional)
+      run = RoundRun.mark_speaker_done(run, :claude_ic, :needs_more_evidence)
+
+      assert run.satisfaction_map[:codex] == :satisfied
+      assert run.satisfaction_map[:gemini] == :satisfied_conditional
+      assert run.satisfaction_map[:claude_ic] == :needs_more_evidence
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # persist/1 and load/1
+  # ------------------------------------------------------------------
+
+  describe "persist/1 and load/1" do
+    test "ETS round-trip" do
+      run = RoundRun.new(@test_issue, [:codex, :gemini])
+      assert :ok = RoundRun.persist(run)
+      assert {:ok, loaded} = RoundRun.load(@test_issue)
+
+      assert loaded.issue_number == @test_issue
+      assert loaded.phase == :awaiting_turns
+      assert loaded.expected_speakers == [:codex, :gemini]
+    end
+
+    test "JSON round-trip when ETS is cold" do
+      run =
+        RoundRun.new(@test_issue, [:codex])
+        |> RoundRun.put_phase(:consensus_check)
+        |> RoundRun.mark_speaker_done(:codex, :satisfied_conditional)
+
+      assert :ok = RoundRun.persist(run)
+
+      # Evict from ETS to force JSON path
+      :ets.delete(:roundtable_round_runs, @test_issue)
+
+      assert {:ok, loaded} = RoundRun.load(@test_issue)
+      assert loaded.phase == :consensus_check
+      assert loaded.expected_speakers == [:codex]
+      assert loaded.satisfaction_map[:codex] == :satisfied_conditional
+    end
+
+    test "returns not_found for unknown issue" do
+      :ets.delete(:roundtable_round_runs, 99_999)
+      File.rm("/tmp/roundtable_test_state/round_run_99999.json")
+
+      assert {:error, :not_found} = RoundRun.load(99_999)
+    end
+
+    test "JSON file contains human-readable phase string" do
+      run = RoundRun.new(@test_issue, [:codex]) |> RoundRun.put_phase(:triage_missing_markers)
+      RoundRun.persist(run)
+
+      {:ok, json} = File.read("/tmp/roundtable_test_state/round_run_#{@test_issue}.json")
+      assert json =~ "triage_missing_markers"
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # build_from_issue/3 (drives reconcile logic, no Gh mock needed)
+  # ------------------------------------------------------------------
+
+  describe "build_from_issue/3" do
+    test "extracts completed_speakers from comment headers" do
+      issue = %{
+        "state" => "open",
+        "labels" => [],
+        "comments" => [
+          %{"id" => "c1", "body" => "## Codex\n\nMy analysis.\n\n[needs more evidence: proof]"},
+          %{"id" => "c2", "body" => "## Gemini\n\nAgreed.\n\n[satisfied]"}
+        ]
+      }
+
+      run = RoundRun.build_from_issue(42, [:codex, :gemini, :claude_ic], issue)
+
+      assert :codex in run.completed_speakers
+      assert :gemini in run.completed_speakers
+      refute :claude_ic in run.completed_speakers
+    end
+
+    test "parses satisfaction markers per speaker" do
+      issue = %{
+        "state" => "open",
+        "labels" => [],
+        "comments" => [
+          %{"id" => "c1", "body" => "## Codex\n\nText.\n\n[satisfied]"},
+          %{"id" => "c2", "body" => "## Gemini\n\nText.\n\n[satisfied-conditional: needs deployment]"},
+          %{"id" => "c3", "body" => "## Claude IC\n\nText.\n\n[needs more evidence: repro steps]"}
+        ]
+      }
+
+      run = RoundRun.build_from_issue(42, [:codex, :gemini, :claude_ic], issue)
+
+      assert run.satisfaction_map[:codex] == :satisfied
+      assert run.satisfaction_map[:gemini] == :satisfied_conditional
+      assert run.satisfaction_map[:claude_ic] == :needs_more_evidence
+    end
+
+    test "infers :closed phase from issue state" do
+      issue = %{"state" => "closed", "labels" => [], "comments" => []}
+      run = RoundRun.build_from_issue(42, [], issue)
+      assert run.phase == :closed
+    end
+
+    test "infers :needs_human_review from label" do
+      issue = %{
+        "state" => "open",
+        "labels" => [%{"name" => "needs-human-review"}],
+        "comments" => []
+      }
+
+      run = RoundRun.build_from_issue(42, [], issue)
+      assert run.phase == :needs_human_review
+    end
+
+    test "defaults to :awaiting_turns for open issue with no special labels" do
+      issue = %{
+        "state" => "open",
+        "labels" => [%{"name" => "satisfied"}],
+        "comments" => []
+      }
+
+      run = RoundRun.build_from_issue(42, [], issue)
+      assert run.phase == :awaiting_turns
+    end
+
+    test "collects comment IDs" do
+      issue = %{
+        "state" => "open",
+        "labels" => [],
+        "comments" => [
+          %{"id" => "101", "body" => "## Codex\n\nText.\n\n[satisfied]"},
+          %{"id" => "102", "body" => "## Gemini\n\nText.\n\n[satisfied]"}
+        ]
+      }
+
+      run = RoundRun.build_from_issue(42, [], issue)
+      assert "101" in run.last_comment_ids
+      assert "102" in run.last_comment_ids
+    end
+
+    test "ignores non-agent comments" do
+      issue = %{
+        "state" => "open",
+        "labels" => [],
+        "comments" => [
+          %{"id" => "1", "body" => "Human comment, no header"},
+          %{"id" => "2", "body" => "## Codex\n\nText.\n\n[satisfied]"}
+        ]
+      }
+
+      run = RoundRun.build_from_issue(42, [:codex, :gemini], issue)
+      assert run.completed_speakers == [:codex]
+    end
+  end
+end


### PR DESCRIPTION
Implements `Roundtable.RoundRun` per the spec in `docs/work-items/11-round-run.md`.

## What's in this PR

- `Roundtable.RoundRun` struct with all specified fields
- ETS hot store (`init/0`, `persist/1`, `load/1`) — `init` called from `Application.start`
- JSON snapshot flush to `state/round_run_<n>.json` (state dir configurable via `config :roundtable, state_dir:`)
- `build_from_issue/3` / `reconcile_from_github/2` — rebuild state from a gh issue JSON map
- 19 unit tests, all pure (no Gh mock needed for reconcile path)

## Fixes bundled

- `Satisfaction.parse_marker`: `"satisfied-conditional"` must be checked before `"satisfied"` — the regex prefix was matching the longer marker as the shorter one
- `Gh.CloseIssue`: invalid list-prepend syntax `key: value | list` → `{:key, value} | list`
- `CLI.inject_question(nil, ...)`: now returns `{:error, :no_repo_configured}` rather than calling `gh` against the ambient git remote

## Closes

Fixes #9

## Next

Item 12 (phase state machine) is now unblocked — it depends on this struct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/agent-roundtable/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added state persistence for round runs with ETS storage and JSON snapshots
  * Improved error handling when repository is not configured

* **Chores**
  * Enhanced application initialization sequence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->