### PR TITLE
feat: OTEL span taxonomy for orchestrator events (item 13)

### DIFF
--- a/roundtable/config/dev.exs
+++ b/roundtable/config/dev.exs
@@ -9,3 +9,9 @@ config :roundtable, RoundtableWeb.Endpoint,
 
 config :logger, :console, format: "[$level] $message\n"
 config :phoenix, :stacktrace_depth, 20
+
+# Attach a JSON-to-stdout telemetry handler for all roundtable spans.
+# To attach an OTEL exporter instead, see https://hex.pm/packages/opentelemetry_exporter
+# and call :telemetry.attach_many/4 with Roundtable.Telemetry.all_events() in your
+# application start, replacing this handler.
+config :roundtable, telemetry_handler: :json_logger

--- a/roundtable/lib/roundtable/application.ex
+++ b/roundtable/lib/roundtable/application.ex
@@ -9,6 +9,10 @@ defmodule Roundtable.Application do
   def start(_type, _args) do
     Roundtable.RoundRun.init()
 
+    if Application.get_env(:roundtable, :telemetry_handler) == :json_logger do
+      Roundtable.Telemetry.attach_logger()
+    end
+
     children =
       [
         {Phoenix.PubSub, name: Roundtable.PubSub},

--- a/roundtable/lib/roundtable/cli.ex
+++ b/roundtable/lib/roundtable/cli.ex
@@ -146,9 +146,10 @@ defmodule Roundtable.CLI do
   """
   @spec inject_question(String.t(), String.t(), keyword()) ::
           {:ok, pos_integer()} | {:error, term()}
+  def inject_question(repo, question_text, opts \\ [])
   def inject_question(nil, _question_text, _opts), do: {:error, :no_repo_configured}
 
-  def inject_question(repo, question_text, opts \\ []) do
+  def inject_question(repo, question_text, opts) do
     gh_config = %{repo: repo}
     title = question_text |> String.split("\n") |> List.first() |> String.slice(0, 120)
     body = "#{question_text}\n\n*Injected via roundtable web interface.*"

--- a/roundtable/lib/roundtable/orchestrator.ex
+++ b/roundtable/lib/roundtable/orchestrator.ex
@@ -31,6 +31,7 @@ defmodule Roundtable.Orchestrator do
   alias Roundtable.Actions.RunCliAgent
   alias Roundtable.Satisfaction
   alias Roundtable.Prompt
+  alias Roundtable.Telemetry
 
   @default_agents [:codex, :gemini, :claude_ic]
   @default_max_rounds 5
@@ -95,6 +96,7 @@ defmodule Roundtable.Orchestrator do
 
   defp do_rounds(question, _brief, _agents, max_rounds, gh_config, opts, round)
        when round > max_rounds do
+    Telemetry.issue_close(question.issue_number, round - 1, :max_rounds)
     Gh.comment_issue(
       question.issue_number,
       "**Roundtable:** Max rounds (#{max_rounds}) reached without consensus. Flagging for human review.",
@@ -113,6 +115,8 @@ defmodule Roundtable.Orchestrator do
   defp do_rounds(question, brief, agents, max_rounds, gh_config, opts, round) do
     notify(opts, {:round_start, question.id, round})
 
+    Telemetry.issue_poll(question.issue_number, gh_config[:repo])
+
     case Gh.view_issue(question.issue_number, [], gh_config) do
       {:error, reason} ->
         notify(opts, {:gh_error, :view_issue, reason})
@@ -121,7 +125,7 @@ defmodule Roundtable.Orchestrator do
       {:ok, issue} ->
         final_issue =
           Enum.reduce(agents, issue, fn agent, current_issue ->
-            case run_agent_turn(question.issue_number, current_issue, brief, agent, gh_config, opts) do
+            case run_agent_turn(question.issue_number, current_issue, brief, agent, gh_config, opts, round) do
               {:ok, updated_issue} -> updated_issue
               {:error, reason} ->
                 notify(opts, {:agent_error, agent, reason})
@@ -130,8 +134,11 @@ defmodule Roundtable.Orchestrator do
           end)
 
         labels = extract_label_names(final_issue)
+        consensus = Satisfaction.consensus?(labels)
+        Telemetry.consensus_check(question.issue_number, labels, consensus)
 
-        if Satisfaction.consensus?(labels) do
+        if consensus do
+          Telemetry.issue_close(question.issue_number, round, :consensus)
           Gh.close_issue(
             question.issue_number,
             [comment: "All agents satisfied. Closed after #{round} round(s)."],
@@ -146,11 +153,12 @@ defmodule Roundtable.Orchestrator do
     end
   end
 
-  defp run_agent_turn(issue_number, issue, brief, agent, gh_config, opts) do
+  defp run_agent_turn(issue_number, issue, brief, agent, gh_config, opts, round) do
     repo_root = Map.get(gh_config, :repo_root, File.cwd!())
     prompt = Prompt.build(brief, issue, agent_role(agent))
 
     notify(opts, {:agent_start, agent, issue_number})
+    Telemetry.agent_turn(agent, issue_number, round)
 
     params = %{
       agent: cli_agent_atom(agent),
@@ -161,10 +169,14 @@ defmodule Roundtable.Orchestrator do
     case RunCliAgent.run(params, %{}) do
       {:ok, %{stdout: raw}} ->
         text = extract_text(raw, agent)
+        comment_body = format_comment(agent, text)
 
-        with :ok <- Gh.comment_issue(issue_number, format_comment(agent, text), gh_config) do
+        Telemetry.gh_comment(issue_number, agent, byte_size(comment_body))
+
+        with :ok <- Gh.comment_issue(issue_number, comment_body, gh_config) do
           notify(opts, {:agent_done, agent, issue_number})
-          label = detect_or_triage_label(issue_number, text, agent, gh_config, opts)
+          {label, method} = detect_or_triage_label(issue_number, text, agent, gh_config, opts)
+          Telemetry.satisfaction_parse(agent, label, method)
 
           case apply_label(issue_number, label, gh_config) do
             :ok -> :ok
@@ -186,14 +198,15 @@ defmodule Roundtable.Orchestrator do
   defp detect_or_triage_label(issue_number, text, agent, gh_config, opts) do
     case Satisfaction.parse_marker(text) do
       nil ->
-        triage_with_ic(issue_number, text, agent, gh_config, opts)
+        label = triage_with_ic(issue_number, text, agent, gh_config, opts)
+        {label, :triage}
 
       label ->
-        label
+        {label, :marker}
     end
   end
 
-  defp triage_with_ic(_issue_number, text, _agent, gh_config, opts) do
+  defp triage_with_ic(issue_number, text, _agent, gh_config, opts) do
     repo_root = Map.get(gh_config, :repo_root, File.cwd!())
     triage_prompt = """
     You are an Incident Commander reviewing an agent's response in a roundtable discussion.
@@ -212,12 +225,16 @@ defmodule Roundtable.Orchestrator do
       {:ok, %{stdout: raw}} ->
         triage_text = extract_text(raw, :claude_ic)
 
-        cond do
-          String.contains?(triage_text, "needs-more-evidence") -> "needs-more-evidence"
-          String.contains?(triage_text, "satisfied-conditional") -> "satisfied-conditional"
-          String.contains?(triage_text, "satisfied") -> "satisfied"
-          true -> notify(opts, {:triage_unclear, triage_text}); nil
-        end
+        result =
+          cond do
+            String.contains?(triage_text, "needs-more-evidence") -> "needs-more-evidence"
+            String.contains?(triage_text, "satisfied-conditional") -> "satisfied-conditional"
+            String.contains?(triage_text, "satisfied") -> "satisfied"
+            true -> notify(opts, {:triage_unclear, triage_text}); nil
+          end
+
+        Telemetry.ic_triage(issue_number, result)
+        result
 
       {:error, _} ->
         nil

--- a/roundtable/lib/roundtable/round_run.ex
+++ b/roundtable/lib/roundtable/round_run.ex
@@ -93,9 +93,10 @@ defmodule Roundtable.RoundRun do
     }
   end
 
-  @doc "Transition to `phase`, stamping `updated_at`."
+  @doc "Transition to `phase`, stamping `updated_at` and emitting a telemetry span."
   @spec put_phase(t(), phase()) :: t()
   def put_phase(%__MODULE__{} = run, phase) do
+    Roundtable.Telemetry.phase_transition(run.issue_number, run.phase, phase)
     %{run | phase: phase, updated_at: DateTime.utc_now()}
   end
 

--- a/roundtable/lib/roundtable/telemetry.ex
+++ b/roundtable/lib/roundtable/telemetry.ex
@@ -165,6 +165,8 @@ defmodule Roundtable.Telemetry do
     entry =
       metadata
       |> Map.new(fn
+        # Preserve booleans and nil so Jason emits true/false/null, not strings.
+        {k, v} when is_boolean(v) or is_nil(v) -> {k, v}
         {k, v} when is_atom(v) -> {k, Atom.to_string(v)}
         {k, v} when is_list(v) -> {k, Enum.map(v, &to_string/1)}
         kv -> kv
@@ -173,7 +175,10 @@ defmodule Roundtable.Telemetry do
       |> Map.put(:timestamp, DateTime.to_iso8601(DateTime.utc_now()))
       |> Map.put(:system_time, Map.get(measurements, :system_time))
 
-    IO.puts(Jason.encode!(entry))
+    case Jason.encode(entry) do
+      {:ok, json} -> IO.puts(json)
+      {:error, _} -> IO.inspect(entry, label: "[roundtable] telemetry encoding error")
+    end
   end
 
   # ------------------------------------------------------------------

--- a/roundtable/lib/roundtable/telemetry.ex
+++ b/roundtable/lib/roundtable/telemetry.ex
@@ -1,0 +1,184 @@
+defmodule Roundtable.Telemetry do
+  @moduledoc """
+  OpenTelemetry-shaped span taxonomy for Roundtable orchestrator events.
+
+  All spans are emitted via `:telemetry.execute/3` so any downstream
+  handler (OTEL exporter, logger, LiveView) can attach without coupling to
+  a specific SDK.
+
+  ## Span names (as `:telemetry` event names)
+
+  | Span                          | When emitted                          |
+  |-------------------------------|---------------------------------------|
+  | `roundtable.issue.poll`       | `Gh.view_issue/3` call                |
+  | `roundtable.agent.turn`       | `RunCliAgent.run/2` start             |
+  | `roundtable.gh.comment`       | `Gh.comment_issue/3` call             |
+  | `roundtable.satisfaction.parse` | after marker extraction             |
+  | `roundtable.ic.triage`        | `triage_with_ic/5` call               |
+  | `roundtable.consensus.check`  | `Satisfaction.consensus?/1` eval      |
+  | `roundtable.issue.close`      | `Gh.close_issue/3` call               |
+  | `roundtable.phase.transition` | every `RoundRun.put_phase/2` call     |
+
+  ## Attaching a handler
+
+  In `config/dev.exs`:
+
+      config :roundtable, telemetry_handler: :json_logger
+
+  The application start will call `Roundtable.Telemetry.attach_logger/0`
+  when this is set, printing structured JSON to stdout.
+
+  In production, attach an `opentelemetry_exporter` handler instead.
+  See: https://hex.pm/packages/opentelemetry_exporter
+
+  ## Example production wiring
+
+      :telemetry.attach_many(
+        "otel-exporter",
+        Roundtable.Telemetry.all_events(),
+        &MyApp.OtelHandler.handle_event/4,
+        nil
+      )
+  """
+
+  @issue_poll [:roundtable, :issue, :poll]
+  @agent_turn [:roundtable, :agent, :turn]
+  @gh_comment [:roundtable, :gh, :comment]
+  @satisfaction_parse [:roundtable, :satisfaction, :parse]
+  @ic_triage [:roundtable, :ic, :triage]
+  @consensus_check [:roundtable, :consensus, :check]
+  @issue_close [:roundtable, :issue, :close]
+  @phase_transition [:roundtable, :phase, :transition]
+
+  @doc "All eight event names — useful for bulk attach."
+  def all_events do
+    [
+      @issue_poll,
+      @agent_turn,
+      @gh_comment,
+      @satisfaction_parse,
+      @ic_triage,
+      @consensus_check,
+      @issue_close,
+      @phase_transition
+    ]
+  end
+
+  # ------------------------------------------------------------------
+  # Span emitters
+  # ------------------------------------------------------------------
+
+  @doc "Emitted when `Gh.view_issue/3` is called."
+  def issue_poll(issue_number, gh_repo) do
+    :telemetry.execute(@issue_poll, ts(), %{
+      issue_number: issue_number,
+      gh_repo: gh_repo
+    })
+  end
+
+  @doc "Emitted at the start of a `RunCliAgent` invocation."
+  def agent_turn(agent, issue_number, round) do
+    :telemetry.execute(@agent_turn, ts(), %{
+      agent: agent,
+      issue_number: issue_number,
+      round: round
+    })
+  end
+
+  @doc "Emitted when `Gh.comment_issue/3` is called."
+  def gh_comment(issue_number, agent, body_bytes) do
+    :telemetry.execute(@gh_comment, ts(), %{
+      issue_number: issue_number,
+      agent: agent,
+      body_bytes: body_bytes
+    })
+  end
+
+  @doc """
+  Emitted after satisfaction marker extraction.
+
+  `method` is `:marker` when the regex matched, `:triage` when the IC
+  classified the response.
+  """
+  def satisfaction_parse(agent, result, method) do
+    :telemetry.execute(@satisfaction_parse, ts(), %{
+      agent: agent,
+      result: result,
+      method: method
+    })
+  end
+
+  @doc "Emitted when the IC triage call is made."
+  def ic_triage(issue_number, result) do
+    :telemetry.execute(@ic_triage, ts(), %{
+      issue_number: issue_number,
+      result: result
+    })
+  end
+
+  @doc "Emitted when `Satisfaction.consensus?/1` is evaluated."
+  def consensus_check(issue_number, labels, result) do
+    :telemetry.execute(@consensus_check, ts(), %{
+      issue_number: issue_number,
+      labels: labels,
+      result: result
+    })
+  end
+
+  @doc "Emitted when `Gh.close_issue/3` is called."
+  def issue_close(issue_number, round, reason) do
+    :telemetry.execute(@issue_close, ts(), %{
+      issue_number: issue_number,
+      round: round,
+      reason: reason
+    })
+  end
+
+  @doc "Emitted on every `RoundRun.put_phase/2` transition."
+  def phase_transition(issue_number, from_phase, to_phase) do
+    :telemetry.execute(@phase_transition, ts(), %{
+      issue_number: issue_number,
+      from_phase: from_phase,
+      to_phase: to_phase
+    })
+  end
+
+  # ------------------------------------------------------------------
+  # Dev JSON logger
+  # ------------------------------------------------------------------
+
+  @doc """
+  Attaches a handler that prints each event as a structured JSON line to
+  stdout. Intended for development; wire an OTEL exporter in production.
+  """
+  def attach_logger do
+    :telemetry.attach_many(
+      "roundtable-json-logger",
+      all_events(),
+      &__MODULE__.handle_event/4,
+      nil
+    )
+  end
+
+  @doc false
+  def handle_event(event, measurements, metadata, _config) do
+    entry =
+      metadata
+      |> Map.new(fn
+        {k, v} when is_atom(v) -> {k, Atom.to_string(v)}
+        {k, v} when is_list(v) -> {k, Enum.map(v, &to_string/1)}
+        kv -> kv
+      end)
+      |> Map.put(:event, Enum.join(event, "."))
+      |> Map.put(:timestamp, DateTime.to_iso8601(DateTime.utc_now()))
+      |> Map.put(:system_time, Map.get(measurements, :system_time))
+
+    IO.puts(Jason.encode!(entry))
+  end
+
+  # ------------------------------------------------------------------
+  # Private
+  # ------------------------------------------------------------------
+
+  defp ts, do: %{system_time: :erlang.system_time()}
+end

--- a/roundtable/test/roundtable/telemetry_test.exs
+++ b/roundtable/test/roundtable/telemetry_test.exs
@@ -1,0 +1,183 @@
+defmodule Roundtable.TelemetryTest do
+  use ExUnit.Case, async: false
+
+  alias Roundtable.Telemetry
+
+  # Capture a single telemetry event into the test process mailbox.
+  defp attach(event, ref) do
+    handler_id = "test-#{inspect(ref)}-#{Enum.join(event, "-")}"
+
+    :telemetry.attach(
+      handler_id,
+      event,
+      fn _event, measurements, metadata, _config ->
+        send(self(), {:telemetry, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  describe "all_events/0" do
+    test "returns 8 event names" do
+      assert length(Telemetry.all_events()) == 8
+    end
+
+    test "each event name is a list of atoms" do
+      for event <- Telemetry.all_events() do
+        assert is_list(event)
+        assert Enum.all?(event, &is_atom/1)
+      end
+    end
+  end
+
+  describe "issue_poll/2" do
+    test "emits [:roundtable, :issue, :poll] with correct metadata" do
+      ref = make_ref()
+      attach([:roundtable, :issue, :poll], ref)
+
+      Telemetry.issue_poll(42, "owner/repo")
+
+      assert_receive {:telemetry, %{system_time: _}, %{issue_number: 42, gh_repo: "owner/repo"}}
+    end
+
+    test "gh_repo may be nil" do
+      ref = make_ref()
+      attach([:roundtable, :issue, :poll], ref)
+
+      Telemetry.issue_poll(1, nil)
+
+      assert_receive {:telemetry, _, %{issue_number: 1, gh_repo: nil}}
+    end
+  end
+
+  describe "agent_turn/3" do
+    test "emits [:roundtable, :agent, :turn] with agent, issue_number, round" do
+      ref = make_ref()
+      attach([:roundtable, :agent, :turn], ref)
+
+      Telemetry.agent_turn(:codex, 7, 2)
+
+      assert_receive {:telemetry, _, %{agent: :codex, issue_number: 7, round: 2}}
+    end
+  end
+
+  describe "gh_comment/3" do
+    test "emits [:roundtable, :gh, :comment] with body_bytes" do
+      ref = make_ref()
+      attach([:roundtable, :gh, :comment], ref)
+
+      Telemetry.gh_comment(10, :gemini, 512)
+
+      assert_receive {:telemetry, _, %{issue_number: 10, agent: :gemini, body_bytes: 512}}
+    end
+  end
+
+  describe "satisfaction_parse/3" do
+    test "emits [:roundtable, :satisfaction, :parse] for marker method" do
+      ref = make_ref()
+      attach([:roundtable, :satisfaction, :parse], ref)
+
+      Telemetry.satisfaction_parse(:codex, "satisfied", :marker)
+
+      assert_receive {:telemetry, _, %{agent: :codex, result: "satisfied", method: :marker}}
+    end
+
+    test "emits for triage method" do
+      ref = make_ref()
+      attach([:roundtable, :satisfaction, :parse], ref)
+
+      Telemetry.satisfaction_parse(:gemini, "needs-more-evidence", :triage)
+
+      assert_receive {:telemetry, _, %{agent: :gemini, result: "needs-more-evidence", method: :triage}}
+    end
+  end
+
+  describe "ic_triage/2" do
+    test "emits [:roundtable, :ic, :triage] with issue_number and result" do
+      ref = make_ref()
+      attach([:roundtable, :ic, :triage], ref)
+
+      Telemetry.ic_triage(5, "satisfied-conditional")
+
+      assert_receive {:telemetry, _, %{issue_number: 5, result: "satisfied-conditional"}}
+    end
+  end
+
+  describe "consensus_check/3" do
+    test "emits [:roundtable, :consensus, :check] with labels and result" do
+      ref = make_ref()
+      attach([:roundtable, :consensus, :check], ref)
+
+      Telemetry.consensus_check(3, ["satisfied", "satisfied-conditional"], true)
+
+      assert_receive {:telemetry, _,
+                      %{issue_number: 3, labels: ["satisfied", "satisfied-conditional"], result: true}}
+    end
+  end
+
+  describe "issue_close/3" do
+    test "emits [:roundtable, :issue, :close] with round and reason" do
+      ref = make_ref()
+      attach([:roundtable, :issue, :close], ref)
+
+      Telemetry.issue_close(8, 3, :consensus)
+
+      assert_receive {:telemetry, _, %{issue_number: 8, round: 3, reason: :consensus}}
+    end
+
+    test "max_rounds reason" do
+      ref = make_ref()
+      attach([:roundtable, :issue, :close], ref)
+
+      Telemetry.issue_close(9, 5, :max_rounds)
+
+      assert_receive {:telemetry, _, %{issue_number: 9, reason: :max_rounds}}
+    end
+  end
+
+  describe "phase_transition/3" do
+    test "emits [:roundtable, :phase, :transition] with from and to phase" do
+      ref = make_ref()
+      attach([:roundtable, :phase, :transition], ref)
+
+      Telemetry.phase_transition(4, :awaiting_turns, :consensus_check)
+
+      assert_receive {:telemetry, _,
+                      %{issue_number: 4, from_phase: :awaiting_turns, to_phase: :consensus_check}}
+    end
+  end
+
+  describe "RoundRun.put_phase/2 integration" do
+    test "put_phase emits phase_transition span" do
+      Roundtable.RoundRun.init()
+      ref = make_ref()
+      attach([:roundtable, :phase, :transition], ref)
+
+      run = Roundtable.RoundRun.new(77_001, [:codex])
+      Roundtable.RoundRun.put_phase(run, :triage_missing_markers)
+
+      assert_receive {:telemetry, _,
+                      %{issue_number: 77_001, from_phase: :awaiting_turns, to_phase: :triage_missing_markers}}
+    end
+  end
+
+  describe "attach_logger/0" do
+    test "attaches without error and handler receives events" do
+      # Detach first in case a prior test left it attached
+      :telemetry.detach("roundtable-json-logger")
+
+      assert :ok = Telemetry.attach_logger()
+
+      # Verify it fires — capture stdout to avoid test noise
+      import ExUnit.CaptureIO
+      output = capture_io(fn -> Telemetry.issue_poll(99, "test/repo") end)
+
+      assert output =~ "roundtable.issue.poll"
+      assert output =~ "\"issue_number\":99"
+
+      :telemetry.detach("roundtable-json-logger")
+    end
+  end
+end


### PR DESCRIPTION
Implements the 8-span telemetry taxonomy from `docs/work-items/13-otel-spans.md`.

## Spans

| Span | Emitted at |
|---|---|
| `roundtable.issue.poll` | `Gh.view_issue/3` call |
| `roundtable.agent.turn` | `RunCliAgent` start |
| `roundtable.gh.comment` | `Gh.comment_issue/3` call |
| `roundtable.satisfaction.parse` | after marker extraction (`:method` is `:marker` or `:triage`) |
| `roundtable.ic.triage` | IC classification call |
| `roundtable.consensus.check` | `Satisfaction.consensus?/1` eval |
| `roundtable.issue.close` | `Gh.close_issue/3` call |
| `roundtable.phase.transition` | every `RoundRun.put_phase/2` |

## Dev wiring

`config/dev.exs` sets `telemetry_handler: :json_logger`. `Application.start` attaches `Roundtable.Telemetry.attach_logger/0`, which prints each event as a JSON line to stdout. No `opentelemetry` SDK required.

To attach an OTEL exporter in production, call `:telemetry.attach_many/4` with `Roundtable.Telemetry.all_events()` — see module docs for the pattern.

## Tests

15 tests using `:telemetry.attach` capture pattern — no mocks, no process spawning.

## Fixes bundled

- `triage_with_ic/5` was ignoring `issue_number` via `_issue_number` — now threaded through to `Telemetry.ic_triage/2`
- `CLI.inject_question/3` multi-clause default value warning fixed with header declaration

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/agent-roundtable/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry instrumentation added throughout orchestrator operations, tracking issue polling, agent turns, GitHub comment generation, consensus checks, and issue closure.
  * JSON logger enabled for development to provide structured event output to stdout.

* **Tests**
  * Comprehensive telemetry test suite added.

* **Refactor**
  * Code structure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->