### PR TITLE
feat: coordinator failover layer (item 14)

### DIFF
--- a/roundtable/lib/roundtable/orchestrator.ex
+++ b/roundtable/lib/roundtable/orchestrator.ex
@@ -33,6 +33,11 @@ defmodule Roundtable.Orchestrator do
         any needs-more-evidence      → :awaiting_turns (next round, reset speakers)
         max_rounds reached           → :needs_human_review
 
+      :coordinator_unavailable
+        standby available            → takeover, resume suspended_phase
+        no standby, max not reached  → :needs_human_input
+        max takeovers reached        → :needs_human_review
+
       :needs_human_input             (HITL interrupt — resume via LiveView)
       :closed                        (terminal)
       :needs_human_review            (terminal)
@@ -53,6 +58,9 @@ defmodule Roundtable.Orchestrator do
   @default_agents [:codex, :gemini, :claude_ic]
   @default_max_rounds 5
   @terminal_phases [:closed, :needs_human_review, :needs_human_input]
+  @default_standby_coordinators [:codex, :gemini]
+  @default_coordinator_lease_seconds 300
+  @default_max_takeovers 2
 
   @label_conflicts %{
     "satisfied" => ["needs-more-evidence", "satisfied-conditional"],
@@ -240,6 +248,66 @@ defmodule Roundtable.Orchestrator do
     end
   end
 
+  def step(%RoundRun{phase: :coordinator_unavailable} = run, _issue, opts) do
+    standbys = Keyword.get(opts, :standby_coordinators, @default_standby_coordinators)
+    max_takeovers = Keyword.get(opts, :max_takeovers, @default_max_takeovers)
+    available = standbys -- [run.coordinator]
+
+    cond do
+      run.takeover_count >= max_takeovers ->
+        Telemetry.issue_close(run.issue_number, run.retry_count, :max_rounds)
+        next_run = RoundRun.put_phase(run, :needs_human_review)
+        comment =
+          "**Roundtable:** Coordinator unavailable and max takeovers (#{max_takeovers}) reached. " <>
+            "Flagging for human review."
+
+        {next_run,
+         [
+           {:gh_comment, run.issue_number, comment},
+           {:gh_label, run.issue_number, ["needs-human-review"], ["coordinator-unavailable"]},
+           {:notify, {:coordinator_max_takeovers, run.issue_number}}
+         ]}
+
+      available != [] ->
+        [standby | _] = available
+        prev = run.coordinator
+
+        case RoundRun.takeover(run, standby) do
+          {:ok, resumed_run} ->
+            Telemetry.coordinator_takeover(run.issue_number, prev, standby)
+            note =
+              "**Roundtable:** Coordinator #{inspect(prev)} timed out. " <>
+                "#{inspect(standby)} taking over from phase `#{run.suspended_phase}`."
+
+            {resumed_run,
+             [
+               {:gh_comment, run.issue_number, note},
+               {:gh_label, run.issue_number, [], ["coordinator-unavailable"]},
+               {:notify, {:coordinator_takeover, run.issue_number, standby}}
+             ]}
+
+          {:error, :no_suspended_phase} ->
+            next_run = RoundRun.put_phase(run, :needs_human_input)
+
+            {next_run,
+             [
+               {:gh_label, run.issue_number, ["needs-human-input"], ["coordinator-unavailable"]},
+               {:notify, {:coordinator_unavailable, run.issue_number}}
+             ]}
+        end
+
+      true ->
+        # No standbys configured — escalate to human
+        next_run = RoundRun.put_phase(run, :needs_human_input)
+
+        {next_run,
+         [
+           {:gh_label, run.issue_number, ["needs-human-input"], ["coordinator-unavailable"]},
+           {:notify, {:coordinator_unavailable, run.issue_number}}
+         ]}
+    end
+  end
+
   def step(%RoundRun{phase: phase} = run, _issue, _opts)
       when phase in @terminal_phases do
     {run, []}
@@ -285,10 +353,25 @@ defmodule Roundtable.Orchestrator do
 
       {:ok, issue} ->
         synced = sync_from_issue(run, issue)
-        {next_run, effects} = step(synced, issue, context.opts)
+        checked = maybe_detect_coordinator_timeout(synced)
+        {next_run, effects} = step(checked, issue, context.opts)
         RoundRun.persist(next_run)
         apply_effects(effects, Map.put(context, :issue, issue))
         run_issue_loop(next_run, context)
+    end
+  end
+
+  # If the coordinator lease has expired, enter :coordinator_unavailable before stepping.
+  defp maybe_detect_coordinator_timeout(run) do
+    now = DateTime.utc_now()
+
+    if run.phase not in @terminal_phases and
+         run.phase != :coordinator_unavailable and
+         RoundRun.coordinator_timed_out?(run, now) do
+      Telemetry.coordinator_timeout(run.issue_number, run.coordinator)
+      RoundRun.enter_coordinator_unavailable(run)
+    else
+      run
     end
   end
 
@@ -303,6 +386,10 @@ defmodule Roundtable.Orchestrator do
     brief = context.brief
     repo_root = Map.get(gh_config, :repo_root, File.cwd!())
     round = Keyword.get(opts, :_current_round, 1)
+    lease_seconds = Keyword.get(opts, :coordinator_lease_seconds, @default_coordinator_lease_seconds)
+
+    # IC claims coordinator lease; any other agent triggers a heartbeat.
+    update_coordinator_lease(agent, issue_number, lease_seconds)
 
     prompt = Prompt.build(brief, issue, agent_role(agent))
     Telemetry.agent_turn(agent, issue_number, round)
@@ -442,6 +529,43 @@ defmodule Roundtable.Orchestrator do
     |> case do
       nil -> nil
       comment -> Map.get(comment, "body", "")
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Coordinator lease helpers
+  # ------------------------------------------------------------------
+
+  # IC claims a fresh coordinator lease; non-IC agents heartbeat the active lease.
+  # Loads the run from ETS, updates, and persists — all side-effectful.
+  defp update_coordinator_lease(agent, issue_number, lease_seconds) do
+    case RoundRun.load(issue_number) do
+      {:ok, run} ->
+        updated =
+          if agent == :claude_ic do
+            case RoundRun.claim_coordinator(run, :claude_ic, lease_seconds) do
+              {:ok, claimed} ->
+                Telemetry.coordinator_lease_claim(
+                  issue_number,
+                  :claude_ic,
+                  claimed.coordinator_lease_expires_at
+                )
+
+                claimed
+
+              {:error, :coordinator_active} ->
+                run
+            end
+          else
+            refreshed = RoundRun.heartbeat(run, lease_seconds)
+            Telemetry.coordinator_heartbeat(issue_number, refreshed.coordinator)
+            refreshed
+          end
+
+        RoundRun.persist(updated)
+
+      {:error, _} ->
+        :ok
     end
   end
 

--- a/roundtable/lib/roundtable/round_run.ex
+++ b/roundtable/lib/roundtable/round_run.ex
@@ -31,6 +31,7 @@ defmodule Roundtable.RoundRun do
           :awaiting_turns
           | :triage_missing_markers
           | :consensus_check
+          | :coordinator_unavailable
           | :needs_human_input
           | :closed
           | :needs_human_review
@@ -46,7 +47,13 @@ defmodule Roundtable.RoundRun do
           last_comment_ids: [String.t()],
           satisfaction_map: %{atom() => satisfaction_result()},
           retry_count: non_neg_integer(),
-          updated_at: DateTime.t()
+          updated_at: DateTime.t(),
+          # Coordinator lease fields
+          coordinator: atom() | nil,
+          coordinator_lease_expires_at: DateTime.t() | nil,
+          last_progress_at: DateTime.t() | nil,
+          suspended_phase: phase() | nil,
+          takeover_count: non_neg_integer()
         }
 
   defstruct [
@@ -57,7 +64,12 @@ defmodule Roundtable.RoundRun do
     :last_comment_ids,
     :satisfaction_map,
     :retry_count,
-    :updated_at
+    :updated_at,
+    :coordinator,
+    :coordinator_lease_expires_at,
+    :last_progress_at,
+    :suspended_phase,
+    takeover_count: 0
   ]
 
   @doc """
@@ -89,8 +101,109 @@ defmodule Roundtable.RoundRun do
       last_comment_ids: [],
       satisfaction_map: %{},
       retry_count: 0,
-      updated_at: DateTime.utc_now()
+      updated_at: DateTime.utc_now(),
+      coordinator: nil,
+      coordinator_lease_expires_at: nil,
+      last_progress_at: nil,
+      suspended_phase: nil,
+      takeover_count: 0
     }
+  end
+
+  @doc """
+  Claim the coordinator role for `agent`.
+
+  Succeeds when no coordinator is active or the existing lease has expired.
+  Returns `{:error, :coordinator_active}` when another coordinator holds a
+  valid lease. Compare-and-set safe for single-node BEAM.
+  """
+  @spec claim_coordinator(t(), atom(), pos_integer()) ::
+          {:ok, t()} | {:error, :coordinator_active}
+  def claim_coordinator(%__MODULE__{} = run, agent, lease_seconds \\ 300) do
+    now = DateTime.utc_now()
+    expires = DateTime.add(now, lease_seconds, :second)
+
+    cond do
+      run.coordinator == nil ->
+        updated = %{
+          run
+          | coordinator: agent,
+            coordinator_lease_expires_at: expires,
+            last_progress_at: now,
+            updated_at: now
+        }
+
+        {:ok, updated}
+
+      coordinator_timed_out?(run, now) ->
+        updated = %{
+          run
+          | coordinator: agent,
+            coordinator_lease_expires_at: expires,
+            last_progress_at: now,
+            updated_at: now
+        }
+
+        {:ok, updated}
+
+      true ->
+        {:error, :coordinator_active}
+    end
+  end
+
+  @doc "Refresh the coordinator's lease, stamping `last_progress_at`."
+  @spec heartbeat(t(), pos_integer()) :: t()
+  def heartbeat(%__MODULE__{} = run, lease_seconds \\ 300) do
+    now = DateTime.utc_now()
+    expires = DateTime.add(now, lease_seconds, :second)
+    %{run | coordinator_lease_expires_at: expires, last_progress_at: now, updated_at: now}
+  end
+
+  @doc "True if the coordinator's lease has expired relative to `now`."
+  @spec coordinator_timed_out?(t(), DateTime.t()) :: boolean()
+  def coordinator_timed_out?(%__MODULE__{coordinator_lease_expires_at: nil}, _now), do: false
+
+  def coordinator_timed_out?(%__MODULE__{coordinator_lease_expires_at: exp}, now) do
+    DateTime.compare(now, exp) != :lt
+  end
+
+  @doc """
+  Suspend the current phase and enter `:coordinator_unavailable`.
+
+  Clears the coordinator slot so a standby can claim it.
+  """
+  @spec enter_coordinator_unavailable(t()) :: t()
+  def enter_coordinator_unavailable(%__MODULE__{} = run) do
+    run
+    |> Map.put(:suspended_phase, run.phase)
+    |> Map.put(:coordinator, nil)
+    |> Map.put(:coordinator_lease_expires_at, nil)
+    |> put_phase(:coordinator_unavailable)
+  end
+
+  @doc """
+  Claim coordinator role as standby and resume from `:suspended_phase`.
+
+  Returns `{:error, :no_suspended_phase}` when there is nothing to resume.
+  """
+  @spec takeover(t(), atom()) :: {:ok, t()} | {:error, :no_suspended_phase}
+  def takeover(%__MODULE__{suspended_phase: nil}, _agent), do: {:error, :no_suspended_phase}
+
+  def takeover(%__MODULE__{} = run, agent) do
+    now = DateTime.utc_now()
+    expires = DateTime.add(now, 300, :second)
+    resume_phase = run.suspended_phase
+
+    next_run =
+      run
+      |> Map.put(:coordinator, agent)
+      |> Map.put(:coordinator_lease_expires_at, expires)
+      |> Map.put(:last_progress_at, now)
+      |> Map.put(:takeover_count, run.takeover_count + 1)
+      |> Map.put(:suspended_phase, nil)
+      |> put_phase(resume_phase)
+
+    {:ok, next_run}
   end
 
   @doc "Transition to `phase`, stamping `updated_at` and emitting a telemetry span."
@@ -206,7 +319,18 @@ defmodule Roundtable.RoundRun do
           {Atom.to_string(k), Atom.to_string(v)}
         end),
       retry_count: run.retry_count,
-      updated_at: DateTime.to_iso8601(run.updated_at)
+      updated_at: DateTime.to_iso8601(run.updated_at),
+      coordinator: if(run.coordinator, do: Atom.to_string(run.coordinator), else: nil),
+      coordinator_lease_expires_at:
+        if(run.coordinator_lease_expires_at,
+          do: DateTime.to_iso8601(run.coordinator_lease_expires_at),
+          else: nil
+        ),
+      last_progress_at:
+        if(run.last_progress_at, do: DateTime.to_iso8601(run.last_progress_at), else: nil),
+      suspended_phase:
+        if(run.suspended_phase, do: Atom.to_string(run.suspended_phase), else: nil),
+      takeover_count: run.takeover_count
     }
 
     case Jason.encode(data, pretty: true) do
@@ -231,7 +355,17 @@ defmodule Roundtable.RoundRun do
             {String.to_existing_atom(k), String.to_existing_atom(v)}
           end),
         retry_count: data["retry_count"],
-        updated_at: parse_datetime(data["updated_at"])
+        updated_at: parse_datetime(data["updated_at"]),
+        coordinator:
+          if(data["coordinator"], do: String.to_existing_atom(data["coordinator"]), else: nil),
+        coordinator_lease_expires_at: parse_datetime_nullable(data["coordinator_lease_expires_at"]),
+        last_progress_at: parse_datetime_nullable(data["last_progress_at"]),
+        suspended_phase:
+          if(data["suspended_phase"],
+            do: String.to_existing_atom(data["suspended_phase"]),
+            else: nil
+          ),
+        takeover_count: Map.get(data, "takeover_count", 0)
       }
 
       {:ok, run}
@@ -247,6 +381,9 @@ defmodule Roundtable.RoundRun do
       _ -> DateTime.utc_now()
     end
   end
+
+  defp parse_datetime_nullable(nil), do: nil
+  defp parse_datetime_nullable(str), do: parse_datetime(str)
 
   # ------------------------------------------------------------------
   # Comment parsing
@@ -302,6 +439,7 @@ defmodule Roundtable.RoundRun do
       state == "closed" -> :closed
       "needs-human-review" in labels -> :needs_human_review
       "needs-human-input" in labels -> :needs_human_input
+      "coordinator-unavailable" in labels -> :coordinator_unavailable
       true -> :awaiting_turns
     end
   end

--- a/roundtable/lib/roundtable/telemetry.ex
+++ b/roundtable/lib/roundtable/telemetry.ex
@@ -8,16 +8,20 @@ defmodule Roundtable.Telemetry do
 
   ## Span names (as `:telemetry` event names)
 
-  | Span                          | When emitted                          |
-  |-------------------------------|---------------------------------------|
-  | `roundtable.issue.poll`       | `Gh.view_issue/3` call                |
-  | `roundtable.agent.turn`       | `RunCliAgent.run/2` start             |
-  | `roundtable.gh.comment`       | `Gh.comment_issue/3` call             |
-  | `roundtable.satisfaction.parse` | after marker extraction             |
-  | `roundtable.ic.triage`        | `triage_with_ic/5` call               |
-  | `roundtable.consensus.check`  | `Satisfaction.consensus?/1` eval      |
-  | `roundtable.issue.close`      | `Gh.close_issue/3` call               |
-  | `roundtable.phase.transition` | every `RoundRun.put_phase/2` call     |
+  | Span                              | When emitted                              |
+  |-----------------------------------|-------------------------------------------|
+  | `roundtable.issue.poll`           | `Gh.view_issue/3` call                    |
+  | `roundtable.agent.turn`           | `RunCliAgent.run/2` start                 |
+  | `roundtable.gh.comment`           | `Gh.comment_issue/3` call                 |
+  | `roundtable.satisfaction.parse`   | after marker extraction                   |
+  | `roundtable.ic.triage`            | `triage_with_ic/5` call                   |
+  | `roundtable.consensus.check`      | `Satisfaction.consensus?/1` eval          |
+  | `roundtable.issue.close`          | `Gh.close_issue/3` call                   |
+  | `roundtable.phase.transition`     | every `RoundRun.put_phase/2` call         |
+  | `roundtable.coordinator.lease.claim` | coordinator claims lease               |
+  | `roundtable.coordinator.heartbeat`   | coordinator heartbeat                  |
+  | `roundtable.coordinator.timeout`     | coordinator lease expiry detected      |
+  | `roundtable.coordinator.takeover`    | standby claims coordinator role        |
 
   ## Attaching a handler
 
@@ -49,8 +53,12 @@ defmodule Roundtable.Telemetry do
   @consensus_check [:roundtable, :consensus, :check]
   @issue_close [:roundtable, :issue, :close]
   @phase_transition [:roundtable, :phase, :transition]
+  @coordinator_lease_claim [:roundtable, :coordinator, :lease, :claim]
+  @coordinator_heartbeat [:roundtable, :coordinator, :heartbeat]
+  @coordinator_timeout [:roundtable, :coordinator, :timeout]
+  @coordinator_takeover [:roundtable, :coordinator, :takeover]
 
-  @doc "All eight event names — useful for bulk attach."
+  @doc "All twelve event names — useful for bulk attach."
   def all_events do
     [
       @issue_poll,
@@ -60,7 +68,11 @@ defmodule Roundtable.Telemetry do
       @ic_triage,
       @consensus_check,
       @issue_close,
-      @phase_transition
+      @phase_transition,
+      @coordinator_lease_claim,
+      @coordinator_heartbeat,
+      @coordinator_timeout,
+      @coordinator_takeover
     ]
   end
 
@@ -140,6 +152,40 @@ defmodule Roundtable.Telemetry do
       issue_number: issue_number,
       from_phase: from_phase,
       to_phase: to_phase
+    })
+  end
+
+  @doc "Emitted when a coordinator claims its lease."
+  def coordinator_lease_claim(issue_number, coordinator, expires_at) do
+    :telemetry.execute(@coordinator_lease_claim, ts(), %{
+      issue_number: issue_number,
+      coordinator: coordinator,
+      expires_at: DateTime.to_iso8601(expires_at)
+    })
+  end
+
+  @doc "Emitted when the coordinator refreshes its lease."
+  def coordinator_heartbeat(issue_number, coordinator) do
+    :telemetry.execute(@coordinator_heartbeat, ts(), %{
+      issue_number: issue_number,
+      coordinator: coordinator
+    })
+  end
+
+  @doc "Emitted when a coordinator lease expiry is detected."
+  def coordinator_timeout(issue_number, coordinator) do
+    :telemetry.execute(@coordinator_timeout, ts(), %{
+      issue_number: issue_number,
+      coordinator: coordinator
+    })
+  end
+
+  @doc "Emitted when a standby agent claims the coordinator role."
+  def coordinator_takeover(issue_number, from_coordinator, to_coordinator) do
+    :telemetry.execute(@coordinator_takeover, ts(), %{
+      issue_number: issue_number,
+      from_coordinator: from_coordinator,
+      to_coordinator: to_coordinator
     })
   end
 

--- a/roundtable/test/roundtable/orchestrator_test.exs
+++ b/roundtable/test/roundtable/orchestrator_test.exs
@@ -251,6 +251,77 @@ defmodule Roundtable.OrchestratorTest do
   end
 
   # ------------------------------------------------------------------
+  # :coordinator_unavailable
+  # ------------------------------------------------------------------
+
+  describe "step/3 :coordinator_unavailable" do
+    test "standby takeover resumes suspended phase with continuity note" do
+      r = run(
+        phase: :coordinator_unavailable,
+        suspended_phase: :consensus_check,
+        coordinator: :claude_ic,
+        takeover_count: 0
+      )
+
+      {next_run, effects} =
+        Orchestrator.step(r, issue(), standby_coordinators: [:codex, :gemini], max_takeovers: 2)
+
+      # Resumes at consensus_check (or awaiting_turns — whatever suspended_phase was)
+      assert next_run.phase == :consensus_check
+      assert next_run.coordinator == :codex
+      assert next_run.takeover_count == 1
+      assert Enum.any?(effects, &match?({:gh_comment, 1001, _}, &1))
+      assert Enum.any?(effects, &match?({:notify, {:coordinator_takeover, 1001, :codex}}, &1))
+    end
+
+    test "escalates to :needs_human_input when no standbys configured" do
+      r = run(
+        phase: :coordinator_unavailable,
+        suspended_phase: :awaiting_turns,
+        takeover_count: 0
+      )
+
+      {next_run, effects} =
+        Orchestrator.step(r, issue(), standby_coordinators: [], max_takeovers: 2)
+
+      assert next_run.phase == :needs_human_input
+      assert Enum.any?(effects, &match?({:notify, {:coordinator_unavailable, 1001}}, &1))
+    end
+
+    test "escalates to :needs_human_review when max takeovers exceeded" do
+      r = run(
+        phase: :coordinator_unavailable,
+        suspended_phase: :awaiting_turns,
+        takeover_count: 2
+      )
+
+      {next_run, effects} =
+        Orchestrator.step(r, issue(), standby_coordinators: [:codex], max_takeovers: 2)
+
+      assert next_run.phase == :needs_human_review
+      assert Enum.any?(effects, &match?({:notify, {:coordinator_max_takeovers, 1001}}, &1))
+    end
+
+    test "standby excludes the timed-out coordinator from candidates" do
+      # claude_ic timed out; codex is standby but claude_ic should not re-claim
+      r = run(
+        phase: :coordinator_unavailable,
+        suspended_phase: :awaiting_turns,
+        coordinator: :claude_ic,
+        takeover_count: 0
+      )
+
+      {next_run, _effects} =
+        Orchestrator.step(r, issue(),
+          standby_coordinators: [:claude_ic, :codex],
+          max_takeovers: 2
+        )
+
+      assert next_run.coordinator == :codex
+    end
+  end
+
+  # ------------------------------------------------------------------
   # Compatibility tests kept from original file
   # ------------------------------------------------------------------
 

--- a/roundtable/test/roundtable/round_run_test.exs
+++ b/roundtable/test/roundtable/round_run_test.exs
@@ -59,6 +59,7 @@ defmodule Roundtable.RoundRunTest do
         :awaiting_turns,
         :triage_missing_markers,
         :consensus_check,
+        :coordinator_unavailable,
         :needs_human_input,
         :closed,
         :needs_human_review
@@ -256,6 +257,166 @@ defmodule Roundtable.RoundRunTest do
 
       run = RoundRun.build_from_issue(42, [:codex, :gemini], issue)
       assert run.completed_speakers == [:codex]
+    end
+
+    test "infers :coordinator_unavailable from label" do
+      issue = %{
+        "state" => "open",
+        "labels" => [%{"name" => "coordinator-unavailable"}],
+        "comments" => []
+      }
+
+      run = RoundRun.build_from_issue(42, [], issue)
+      assert run.phase == :coordinator_unavailable
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Coordinator lease / failover
+  # ------------------------------------------------------------------
+
+  describe "claim_coordinator/3" do
+    test "claims when no coordinator is active" do
+      run = RoundRun.new(@test_issue, [:codex])
+      assert {:ok, claimed} = RoundRun.claim_coordinator(run, :claude_ic, 300)
+
+      assert claimed.coordinator == :claude_ic
+      assert %DateTime{} = claimed.coordinator_lease_expires_at
+      assert %DateTime{} = claimed.last_progress_at
+    end
+
+    test "fails when an active coordinator holds a valid lease" do
+      run = RoundRun.new(@test_issue, [:codex])
+      {:ok, run} = RoundRun.claim_coordinator(run, :claude_ic, 300)
+
+      assert {:error, :coordinator_active} = RoundRun.claim_coordinator(run, :codex, 300)
+    end
+
+    test "succeeds when existing lease has expired" do
+      run = RoundRun.new(@test_issue, [:codex])
+      past = DateTime.add(DateTime.utc_now(), -10, :second)
+
+      run = %{
+        run
+        | coordinator: :claude_ic,
+          coordinator_lease_expires_at: past
+      }
+
+      assert {:ok, claimed} = RoundRun.claim_coordinator(run, :codex, 300)
+      assert claimed.coordinator == :codex
+    end
+  end
+
+  describe "heartbeat/2" do
+    test "refreshes lease expiry and last_progress_at" do
+      run = RoundRun.new(@test_issue, [:codex])
+      {:ok, run} = RoundRun.claim_coordinator(run, :claude_ic, 10)
+      old_expires = run.coordinator_lease_expires_at
+
+      Process.sleep(2)
+      refreshed = RoundRun.heartbeat(run, 300)
+
+      assert DateTime.compare(refreshed.coordinator_lease_expires_at, old_expires) == :gt
+      assert DateTime.compare(refreshed.last_progress_at, run.last_progress_at) == :gt
+    end
+  end
+
+  describe "coordinator_timed_out?/2" do
+    test "returns false when no lease set" do
+      run = RoundRun.new(@test_issue, [:codex])
+      refute RoundRun.coordinator_timed_out?(run, DateTime.utc_now())
+    end
+
+    test "returns false before expiry" do
+      run = RoundRun.new(@test_issue, [:codex])
+      {:ok, run} = RoundRun.claim_coordinator(run, :claude_ic, 300)
+
+      refute RoundRun.coordinator_timed_out?(run, DateTime.utc_now())
+    end
+
+    test "returns true after expiry" do
+      run = RoundRun.new(@test_issue, [:codex])
+      {:ok, run} = RoundRun.claim_coordinator(run, :claude_ic, 300)
+      future = DateTime.add(DateTime.utc_now(), 400, :second)
+
+      assert RoundRun.coordinator_timed_out?(run, future)
+    end
+  end
+
+  describe "enter_coordinator_unavailable/1" do
+    test "suspends current phase and transitions to :coordinator_unavailable" do
+      run = RoundRun.new(@test_issue, [:codex]) |> RoundRun.put_phase(:consensus_check)
+      {:ok, run} = RoundRun.claim_coordinator(run, :claude_ic, 300)
+
+      unavailable = RoundRun.enter_coordinator_unavailable(run)
+
+      assert unavailable.phase == :coordinator_unavailable
+      assert unavailable.suspended_phase == :consensus_check
+      assert unavailable.coordinator == nil
+      assert unavailable.coordinator_lease_expires_at == nil
+    end
+  end
+
+  describe "takeover/2" do
+    test "resumes suspended phase with new coordinator" do
+      run =
+        RoundRun.new(@test_issue, [:codex])
+        |> RoundRun.put_phase(:consensus_check)
+        |> RoundRun.enter_coordinator_unavailable()
+
+      assert {:ok, resumed} = RoundRun.takeover(run, :codex)
+
+      assert resumed.phase == :consensus_check
+      assert resumed.coordinator == :codex
+      assert resumed.suspended_phase == nil
+      assert resumed.takeover_count == 1
+    end
+
+    test "increments takeover_count on each takeover" do
+      run =
+        RoundRun.new(@test_issue, [:codex])
+        |> RoundRun.enter_coordinator_unavailable()
+
+      {:ok, run} = RoundRun.takeover(run, :codex)
+      run = RoundRun.enter_coordinator_unavailable(run)
+      {:ok, run} = RoundRun.takeover(run, :gemini)
+
+      assert run.takeover_count == 2
+    end
+
+    test "returns error when no suspended phase" do
+      run = RoundRun.new(@test_issue, [:codex])
+      assert {:error, :no_suspended_phase} = RoundRun.takeover(run, :codex)
+    end
+  end
+
+  describe "coordinator fields JSON round-trip" do
+    test "coordinator fields survive persist/load cycle" do
+      run = RoundRun.new(@test_issue, [:codex, :gemini])
+      {:ok, run} = RoundRun.claim_coordinator(run, :claude_ic, 300)
+      run = %{run | takeover_count: 1}
+
+      assert :ok = RoundRun.persist(run)
+      :ets.delete(:roundtable_round_runs, @test_issue)
+      assert {:ok, loaded} = RoundRun.load(@test_issue)
+
+      assert loaded.coordinator == :claude_ic
+      assert %DateTime{} = loaded.coordinator_lease_expires_at
+      assert %DateTime{} = loaded.last_progress_at
+      assert loaded.takeover_count == 1
+    end
+
+    test "nil coordinator fields round-trip as nil" do
+      run = RoundRun.new(@test_issue, [:codex])
+      assert :ok = RoundRun.persist(run)
+      :ets.delete(:roundtable_round_runs, @test_issue)
+      assert {:ok, loaded} = RoundRun.load(@test_issue)
+
+      assert loaded.coordinator == nil
+      assert loaded.coordinator_lease_expires_at == nil
+      assert loaded.last_progress_at == nil
+      assert loaded.suspended_phase == nil
+      assert loaded.takeover_count == 0
     end
   end
 end

--- a/roundtable/test/roundtable/telemetry_test.exs
+++ b/roundtable/test/roundtable/telemetry_test.exs
@@ -20,8 +20,8 @@ defmodule Roundtable.TelemetryTest do
   end
 
   describe "all_events/0" do
-    test "returns 8 event names" do
-      assert length(Telemetry.all_events()) == 8
+    test "returns 12 event names" do
+      assert length(Telemetry.all_events()) == 12
     end
 
     test "each event name is a list of atoms" do
@@ -160,6 +160,52 @@ defmodule Roundtable.TelemetryTest do
 
       assert_receive {:telemetry, _,
                       %{issue_number: 77_001, from_phase: :awaiting_turns, to_phase: :triage_missing_markers}}
+    end
+  end
+
+  describe "coordinator_lease_claim/3" do
+    test "emits [:roundtable, :coordinator, :lease, :claim] with coordinator and expires_at" do
+      ref = make_ref()
+      attach([:roundtable, :coordinator, :lease, :claim], ref)
+      expires = DateTime.add(DateTime.utc_now(), 300, :second)
+
+      Telemetry.coordinator_lease_claim(20, :claude_ic, expires)
+
+      assert_receive {:telemetry, _, %{issue_number: 20, coordinator: :claude_ic, expires_at: _}}
+    end
+  end
+
+  describe "coordinator_heartbeat/2" do
+    test "emits [:roundtable, :coordinator, :heartbeat]" do
+      ref = make_ref()
+      attach([:roundtable, :coordinator, :heartbeat], ref)
+
+      Telemetry.coordinator_heartbeat(21, :claude_ic)
+
+      assert_receive {:telemetry, _, %{issue_number: 21, coordinator: :claude_ic}}
+    end
+  end
+
+  describe "coordinator_timeout/2" do
+    test "emits [:roundtable, :coordinator, :timeout]" do
+      ref = make_ref()
+      attach([:roundtable, :coordinator, :timeout], ref)
+
+      Telemetry.coordinator_timeout(22, :claude_ic)
+
+      assert_receive {:telemetry, _, %{issue_number: 22, coordinator: :claude_ic}}
+    end
+  end
+
+  describe "coordinator_takeover/3" do
+    test "emits [:roundtable, :coordinator, :takeover] with from and to" do
+      ref = make_ref()
+      attach([:roundtable, :coordinator, :takeover], ref)
+
+      Telemetry.coordinator_takeover(23, :claude_ic, :codex)
+
+      assert_receive {:telemetry, _,
+                      %{issue_number: 23, from_coordinator: :claude_ic, to_coordinator: :codex}}
     end
   end
 


### PR DESCRIPTION
## Summary

Cherry-pick of item 14 onto main. PR #16 accidentally targeted `feat/phase-machine` instead of `main`; this PR corrects that.

- `RoundRun`: 5 new coordinator fields (`coordinator`, `coordinator_lease_expires_at`, `last_progress_at`, `suspended_phase`, `takeover_count`)
- `RoundRun`: `claim_coordinator/3`, `heartbeat/2`, `coordinator_timed_out?/2`, `enter_coordinator_unavailable/1`, `takeover/2`
- `Orchestrator`: `:coordinator_unavailable` step/3 clause (three exit paths)
- `Telemetry`: 4 new coordinator spans (lease claim, heartbeat, timeout, takeover)
- Tests for all new behaviour; 65+ tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/agent-roundtable/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
