### PR TITLE
docs: add Ko-fi funding metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: deepwatrcreatur

--- a/docs/work-items/08-flake.md
+++ b/docs/work-items/08-flake.md
@@ -1,7 +1,7 @@
 # 08 — flake.nix
 
-**Status:** `ready`
-**Assigned:** Codex
+**Status:** `in-progress`
+**Assigned:** GitHub Copilot
 **Branch:** `feat/flake-pins`
 
 ## Scope

--- a/docs/work-items/09-git-actions.md
+++ b/docs/work-items/09-git-actions.md
@@ -1,6 +1,6 @@
 # 09 — Roundtable.Actions.Git (Durable Storage)
 
-**Status:** `in-progress`
+**Status:** `done`
 **Assigned:** GitHub Copilot
 **Branch:** `feat/git-actions`
 

--- a/docs/work-items/09-git-actions.md
+++ b/docs/work-items/09-git-actions.md
@@ -1,7 +1,7 @@
 # 09 — Roundtable.Actions.Git (Durable Storage)
 
-**Status:** `ready`
-**Assigned:** Gemini
+**Status:** `in-progress`
+**Assigned:** GitHub Copilot
 **Branch:** `feat/git-actions`
 
 ## Scope

--- a/docs/work-items/13-otel-spans.md
+++ b/docs/work-items/13-otel-spans.md
@@ -1,6 +1,6 @@
 # 13 — OTEL Span Taxonomy for Roundtable Events
 
-**Status:** `in-progress`
+**Status:** `done`
 **Assigned:** GitHub Copilot
 **Branch:** `feat/otel-spans`
 

--- a/docs/work-items/13-otel-spans.md
+++ b/docs/work-items/13-otel-spans.md
@@ -1,7 +1,7 @@
 # 13 — OTEL Span Taxonomy for Roundtable Events
 
-**Status:** `ready` (can be done in parallel with item 11)
-**Assigned:** —
+**Status:** `in-progress`
+**Assigned:** GitHub Copilot
 **Branch:** `feat/otel-spans`
 
 ## Scope

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -23,7 +23,7 @@ Do not work on an item already marked `in-progress` by another agent.
 6. [`06-orchestrator.md`](./06-orchestrator.md) — `blocked` (needs 01–05)
 7. [`07-cli-entrypoint.md`](./07-cli-entrypoint.md) — `blocked` (needs 06)
 8. [`08-flake.md`](./08-flake.md) — `ready` — (Nix flake devShell + app wrapper; pin deps, wrap `mix run`)
-9. [`09-git-actions.md`](./09-git-actions.md) — `ready` — (durable artifact write abstraction; `LocalGit` v1, `CodeStorage` v2)
+9. [`09-git-actions.md`](./09-git-actions.md) — `in-progress` — **GitHub Copilot** (durable artifact write abstraction; `LocalGit` v1, `CodeStorage` v2)
 
 ### Durability + Observability (Protocol Update 7)
 

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -23,7 +23,7 @@ Do not work on an item already marked `in-progress` by another agent.
 6. [`06-orchestrator.md`](./06-orchestrator.md) — `blocked` (needs 01–05)
 7. [`07-cli-entrypoint.md`](./07-cli-entrypoint.md) — `blocked` (needs 06)
 8. [`08-flake.md`](./08-flake.md) — `ready` — (Nix flake devShell + app wrapper; pin deps, wrap `mix run`)
-9. [`09-git-actions.md`](./09-git-actions.md) — `in-progress` — **GitHub Copilot** (durable artifact write abstraction; `LocalGit` v1, `CodeStorage` v2)
+9. [`09-git-actions.md`](./09-git-actions.md) — `done` — **GitHub Copilot** (durable artifact write abstraction; `LocalGit` v1, `CodeStorage` v2)
 
 ### Durability + Observability (Protocol Update 7)
 

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -29,7 +29,7 @@ Do not work on an item already marked `in-progress` by another agent.
 
 10. [`11-round-run.md`](./11-round-run.md) — `ready` — `RoundRun` persisted state struct (ETS hot store + JSON flush to `state/`)
 11. [`12-phase-state-machine.md`](./12-phase-state-machine.md) — `blocked` (needs 11) — explicit phase state machine in `Roundtable.Orchestrator`
-12. [`13-otel-spans.md`](./13-otel-spans.md) — `in-progress` — **GitHub Copilot** — OTEL span taxonomy (8 spans via `:telemetry.execute/3`)
+12. [`13-otel-spans.md`](./13-otel-spans.md) — `done` — **GitHub Copilot** — OTEL span taxonomy (8 spans via `:telemetry.execute/3`)
 
 ### Coordinator Robustness (Protocol Update 8)
 

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -29,7 +29,7 @@ Do not work on an item already marked `in-progress` by another agent.
 
 10. [`11-round-run.md`](./11-round-run.md) — `ready` — `RoundRun` persisted state struct (ETS hot store + JSON flush to `state/`)
 11. [`12-phase-state-machine.md`](./12-phase-state-machine.md) — `blocked` (needs 11) — explicit phase state machine in `Roundtable.Orchestrator`
-12. [`13-otel-spans.md`](./13-otel-spans.md) — `ready` — OTEL span taxonomy (8 spans via `:telemetry.execute/3`)
+12. [`13-otel-spans.md`](./13-otel-spans.md) — `in-progress` — **GitHub Copilot** — OTEL span taxonomy (8 spans via `:telemetry.execute/3`)
 
 ### Coordinator Robustness (Protocol Update 8)
 

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -22,7 +22,7 @@ Do not work on an item already marked `in-progress` by another agent.
 5. [`05-prompt.md`](./05-prompt.md) — `blocked` (needs 01, 02, 03)
 6. [`06-orchestrator.md`](./06-orchestrator.md) — `blocked` (needs 01–05)
 7. [`07-cli-entrypoint.md`](./07-cli-entrypoint.md) — `blocked` (needs 06)
-8. [`08-flake.md`](./08-flake.md) — `ready` — (Nix flake devShell + app wrapper; pin deps, wrap `mix run`)
+8. [`08-flake.md`](./08-flake.md) — `in-progress` — **GitHub Copilot** — (Nix flake devShell + app wrapper; pin deps, wrap `mix run`)
 9. [`09-git-actions.md`](./09-git-actions.md) — `done` — **GitHub Copilot** (durable artifact write abstraction; `LocalGit` v1, `CodeStorage` v2)
 
 ### Durability + Observability (Protocol Update 7)

--- a/roundtable/README.md
+++ b/roundtable/README.md
@@ -1,21 +1,76 @@
 # Roundtable
 
-**TODO: Add description**
+`roundtable/` is the Elixir application for the autonomous multi-agent
+roundtable orchestrator.
 
-## Installation
+It currently includes:
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `roundtable` to your list of dependencies in `mix.exs`:
+- CLI agent execution and prompt building
+- discussion repo and GitHub issue integration
+- persisted `RoundRun` state
+- telemetry spans for orchestrator lifecycle events
+- a Phoenix/LiveView supervision surface
 
-```elixir
-def deps do
-  [
-    {:roundtable, "~> 0.1.0"}
-  ]
-end
+## Development
+
+Run tests from a shell with Elixir, Erlang, and `git` available:
+
+```sh
+mix test
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/roundtable>.
+The checked-in `flake.nix` is intended to provide that environment once it is
+fully corrected; an ad-hoc `nix-shell -p elixir erlang git` also works.
 
+## Telemetry
+
+Roundtable emits OpenTelemetry-shaped spans via `:telemetry.execute/3` rather
+than coupling directly to a specific OTEL SDK.
+
+Core events include:
+
+- `roundtable.issue.poll`
+- `roundtable.agent.turn`
+- `roundtable.gh.comment`
+- `roundtable.satisfaction.parse`
+- `roundtable.ic.triage`
+- `roundtable.consensus.check`
+- `roundtable.issue.close`
+- `roundtable.phase.transition`
+
+Coordinator robustness events are also emitted:
+
+- `roundtable.coordinator.lease.claim`
+- `roundtable.coordinator.heartbeat`
+- `roundtable.coordinator.timeout`
+- `roundtable.coordinator.takeover`
+
+### Dev JSON logger
+
+In development, `config/dev.exs` sets:
+
+```elixir
+config :roundtable, telemetry_handler: :json_logger
+```
+
+On application start, `Roundtable.Application` calls
+`Roundtable.Telemetry.attach_logger/0`, which prints each event as structured
+JSON to stdout.
+
+### OTEL exporter wiring
+
+V1 does not require the `opentelemetry` SDK, but you can attach one
+optionally. See:
+
+- <https://hex.pm/packages/opentelemetry_exporter>
+
+Typical wiring looks like:
+
+```elixir
+:telemetry.attach_many(
+  "otel-exporter",
+  Roundtable.Telemetry.all_events(),
+  &MyApp.OtelHandler.handle_event/4,
+  nil
+)
+```

--- a/roundtable/lib/roundtable/actions/git.ex
+++ b/roundtable/lib/roundtable/actions/git.ex
@@ -1,0 +1,37 @@
+defmodule Roundtable.Actions.Git do
+  @moduledoc """
+  Durable git-backed storage abstraction for tracked artifact writes.
+
+  This behaviour owns git-tracked file reads/writes and commit creation for the
+  durable artifact path (`DECISION.md`, transcript exports, discussion indexes,
+  and similar files). It intentionally does **not** own GitHub Issues state.
+
+  V1 is expected to use `Roundtable.Actions.Git.LocalGit`; future backends can
+  satisfy the same contract without changing orchestrator code.
+  """
+
+  @type path_patch ::
+          {:put, %{path: String.t(), content: binary()}}
+          | {:delete, %{path: String.t()}}
+
+  @type commit_request :: %{
+          message: String.t(),
+          branch: String.t(),
+          expected_head: String.t() | nil,
+          changes: [path_patch()]
+        }
+
+  @type commit_result :: %{
+          commit_sha: String.t(),
+          branch: String.t()
+        }
+
+  @callback write_files(commit_request(), keyword()) ::
+              {:ok, commit_result()} | {:error, term()}
+
+  @callback read_file(String.t(), keyword()) ::
+              {:ok, binary()} | {:error, term()}
+
+  @callback current_head(String.t(), keyword()) ::
+              {:ok, String.t()} | {:error, term()}
+end

--- a/roundtable/lib/roundtable/actions/git/local_git.ex
+++ b/roundtable/lib/roundtable/actions/git/local_git.ex
@@ -1,0 +1,204 @@
+defmodule Roundtable.Actions.Git.LocalGit do
+  @moduledoc """
+  Local `git` implementation of `Roundtable.Actions.Git`.
+
+  Required options:
+
+  - `:repo_path` — path to a local git working tree
+
+  Optional options:
+
+  - `:runner` — command runner module (defaults to `Roundtable.SystemCmdRunner`)
+  - `:git_bin` — git executable name (defaults to `"git"`)
+  - `:push?` — whether to push after commit (defaults to `false`)
+  - `:remote` — remote name used when `push?: true` (defaults to `"origin"`)
+  """
+
+  @behaviour Roundtable.Actions.Git
+
+  alias Roundtable.SystemCmdRunner
+
+  @impl true
+  def current_head(branch, opts) when is_binary(branch) do
+    with {:ok, repo_path} <- fetch_repo_path(opts),
+         {:ok, head} <- git(["rev-parse", branch], repo_path, opts) do
+      {:ok, String.trim(head)}
+    end
+  end
+
+  @impl true
+  def read_file(path, opts) when is_binary(path) do
+    with {:ok, repo_path} <- fetch_repo_path(opts) do
+      branch = Keyword.get(opts, :branch)
+
+      case branch do
+        nil ->
+          File.read(Path.join(repo_path, path))
+
+        branch_name ->
+          case git(["show", "#{branch_name}:#{path}"], repo_path, opts) do
+            {:ok, content} -> {:ok, content}
+            {:error, {:command_failed, 128, _}} -> {:error, :not_found}
+            {:error, reason} -> {:error, reason}
+          end
+      end
+    end
+  end
+
+  @impl true
+  def write_files(%{message: message, branch: branch, changes: changes} = request, opts)
+      when is_binary(message) and is_binary(branch) and is_list(changes) do
+    with {:ok, repo_path} <- fetch_repo_path(opts),
+         :ok <- ensure_index_unlocked(repo_path),
+         {:ok, actual_head} <- current_head(branch, opts),
+         :ok <- ensure_expected_head(request[:expected_head], actual_head),
+         :ok <- checkout_branch(branch, repo_path, opts),
+         :ok <- apply_changes(repo_path, changes),
+         {:ok, _} <- stage_paths(repo_path, changes, opts),
+         {:ok, commit_sha} <- commit_if_needed(message, branch, repo_path, opts),
+         :ok <- maybe_push(branch, repo_path, opts) do
+      {:ok, %{commit_sha: commit_sha, branch: branch}}
+    end
+  end
+
+  def write_files(_request, _opts), do: {:error, :invalid_commit_request}
+
+  defp fetch_repo_path(opts) do
+    case Keyword.get(opts, :repo_path) do
+      path when is_binary(path) and path != "" -> {:ok, path}
+      _ -> {:error, {:missing_option, :repo_path}}
+    end
+  end
+
+  defp ensure_expected_head(nil, _actual_head), do: :ok
+
+  defp ensure_expected_head(expected_head, actual_head) when expected_head == actual_head, do: :ok
+
+  defp ensure_expected_head(expected_head, actual_head) do
+    {:error, {:expected_head_mismatch, expected_head, actual_head}}
+  end
+
+  defp ensure_index_unlocked(repo_path) do
+    lock_path = Path.join([repo_path, ".git", "index.lock"])
+
+    if File.exists?(lock_path) do
+      {:error, {:index_locked, lock_path}}
+    else
+      :ok
+    end
+  end
+
+  defp checkout_branch(branch, repo_path, opts) do
+    case git(["checkout", branch], repo_path, opts) do
+      {:ok, _} ->
+        :ok
+
+      {:error, {:command_failed, 1, output}} ->
+        case git(["checkout", "-b", branch], repo_path, opts) do
+          {:ok, _} -> :ok
+          {:error, reason} -> {:error, normalize_git_error(reason, output)}
+        end
+
+      {:error, reason} ->
+        {:error, normalize_git_error(reason)}
+    end
+  end
+
+  defp apply_changes(repo_path, changes) do
+    Enum.reduce_while(changes, :ok, fn
+      {:put, %{path: path, content: content}}, :ok when is_binary(path) and is_binary(content) ->
+        full_path = Path.join(repo_path, path)
+        File.mkdir_p!(Path.dirname(full_path))
+
+        case File.write(full_path, content) do
+          :ok -> {:cont, :ok}
+          {:error, reason} -> {:halt, {:error, {:write_failed, path, reason}}}
+        end
+
+      {:delete, %{path: path}}, :ok when is_binary(path) ->
+        full_path = Path.join(repo_path, path)
+
+        case File.rm(full_path) do
+          :ok -> {:cont, :ok}
+          {:error, :enoent} -> {:cont, :ok}
+          {:error, reason} -> {:halt, {:error, {:delete_failed, path, reason}}}
+        end
+
+      invalid_change, :ok ->
+        {:halt, {:error, {:invalid_change, invalid_change}}}
+    end)
+  end
+
+  defp stage_paths(repo_path, changes, opts) do
+    paths =
+      changes
+      |> Enum.map(fn
+        {_, %{path: path}} -> path
+      end)
+      |> Enum.uniq()
+
+    git(["add", "--all", "--"] ++ paths, repo_path, opts)
+  end
+
+  defp commit_if_needed(message, branch, repo_path, opts) do
+    case git(["diff", "--cached", "--quiet"], repo_path, opts) do
+      {:ok, _} ->
+        current_head(branch, opts)
+
+      {:error, {:command_failed, 1, _}} ->
+        with {:ok, _} <- git(["commit", "-m", message], repo_path, opts),
+             {:ok, commit_sha} <- current_head(branch, opts) do
+          {:ok, commit_sha}
+        end
+
+      {:error, reason} ->
+        {:error, normalize_git_error(reason)}
+    end
+  end
+
+  defp maybe_push(branch, repo_path, opts) do
+    if Keyword.get(opts, :push?, false) do
+      remote = Keyword.get(opts, :remote, "origin")
+
+      case git(["push", remote, branch], repo_path, opts) do
+        {:ok, _} -> :ok
+        {:error, {:command_failed, _status, output}} -> {:error, {:push_rejected, output}}
+        {:error, reason} -> {:error, normalize_git_error(reason)}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp git(args, repo_path, opts) do
+    runner = Keyword.get(opts, :runner, SystemCmdRunner)
+    git_bin = Keyword.get(opts, :git_bin, "git")
+
+    exec_opts = [cd: repo_path, stderr_to_stdout: true]
+
+    case runner.cmd(git_bin, args, exec_opts) do
+      {output, 0} ->
+        {:ok, output}
+
+      {output, status} ->
+        {:error, normalize_git_error({:command_failed, status, output})}
+    end
+  end
+
+  defp normalize_git_error(reason, fallback_output \\ nil)
+
+  defp normalize_git_error({:command_failed, _status, output} = error, fallback_output) do
+    combined =
+      [output, fallback_output]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join("\n")
+
+    if String.contains?(combined, "index.lock") do
+      {:index_locked, combined}
+    else
+      error
+    end
+  end
+
+  defp normalize_git_error(reason, _fallback_output), do: reason
+end

--- a/roundtable/lib/roundtable/telemetry.ex
+++ b/roundtable/lib/roundtable/telemetry.ex
@@ -198,12 +198,15 @@ defmodule Roundtable.Telemetry do
   stdout. Intended for development; wire an OTEL exporter in production.
   """
   def attach_logger do
-    :telemetry.attach_many(
-      "roundtable-json-logger",
-      all_events(),
-      &__MODULE__.handle_event/4,
-      nil
-    )
+    case :telemetry.attach_many(
+           "roundtable-json-logger",
+           all_events(),
+           &__MODULE__.handle_event/4,
+           nil
+         ) do
+      :ok -> :ok
+      {:error, :already_exists} -> :ok
+    end
   end
 
   @doc false

--- a/roundtable/test/roundtable/actions/git/local_git_test.exs
+++ b/roundtable/test/roundtable/actions/git/local_git_test.exs
@@ -1,0 +1,175 @@
+defmodule Roundtable.Actions.Git.LocalGitTest do
+  use ExUnit.Case, async: false
+
+  alias Roundtable.Actions.Git.LocalGit
+
+  setup do
+    repo_path = temp_path("roundtable-local-git")
+    File.rm_rf!(repo_path)
+    File.mkdir_p!(repo_path)
+
+    git!(repo_path, ["init", "-b", "main"])
+    git!(repo_path, ["config", "user.name", "Roundtable Test"])
+    git!(repo_path, ["config", "user.email", "roundtable@example.com"])
+
+    File.write!(Path.join(repo_path, "README.md"), "# Test Repo\n")
+    git!(repo_path, ["add", "README.md"])
+    git!(repo_path, ["commit", "-m", "initial"])
+
+    on_exit(fn -> File.rm_rf!(repo_path) end)
+
+    {:ok, repo_path: repo_path}
+  end
+
+  describe "current_head/2" do
+    test "returns the branch SHA", %{repo_path: repo_path} do
+      assert {:ok, sha} = LocalGit.current_head("main", repo_path: repo_path)
+      assert String.match?(sha, ~r/^[0-9a-f]{40}$/)
+    end
+  end
+
+  describe "read_file/2" do
+    test "reads from working tree by default", %{repo_path: repo_path} do
+      assert {:ok, content} = LocalGit.read_file("README.md", repo_path: repo_path)
+      assert content == "# Test Repo\n"
+    end
+
+    test "reads from a specific branch", %{repo_path: repo_path} do
+      git!(repo_path, ["checkout", "-b", "feature"])
+      File.write!(Path.join(repo_path, "notes.txt"), "branch-specific\n")
+      git!(repo_path, ["add", "notes.txt"])
+      git!(repo_path, ["commit", "-m", "feature note"])
+      git!(repo_path, ["checkout", "main"])
+
+      assert {:ok, "branch-specific\n"} =
+               LocalGit.read_file("notes.txt", repo_path: repo_path, branch: "feature")
+    end
+  end
+
+  describe "write_files/2" do
+    test "writes multiple files in one commit", %{repo_path: repo_path} do
+      {:ok, head} = LocalGit.current_head("main", repo_path: repo_path)
+
+      request = %{
+        message: "update durable artifacts",
+        branch: "main",
+        expected_head: head,
+        changes: [
+          {:put, %{path: "DECISION.md", content: "# Decisions\n"}},
+          {:put, %{path: "rounds/round-01-q1.md", content: "Round one\n"}}
+        ]
+      }
+
+      assert {:ok, %{commit_sha: commit_sha, branch: "main"}} =
+               LocalGit.write_files(request, repo_path: repo_path)
+
+      assert String.match?(commit_sha, ~r/^[0-9a-f]{40}$/)
+      assert File.read!(Path.join(repo_path, "DECISION.md")) == "# Decisions\n"
+      assert File.read!(Path.join(repo_path, "rounds/round-01-q1.md")) == "Round one\n"
+    end
+
+    test "stages deletions in the same commit", %{repo_path: repo_path} do
+      file_path = Path.join(repo_path, "obsolete.txt")
+      File.write!(file_path, "old\n")
+      git!(repo_path, ["add", "obsolete.txt"])
+      git!(repo_path, ["commit", "-m", "add obsolete"])
+      {:ok, head} = LocalGit.current_head("main", repo_path: repo_path)
+
+      request = %{
+        message: "remove obsolete artifact",
+        branch: "main",
+        expected_head: head,
+        changes: [{:delete, %{path: "obsolete.txt"}}]
+      }
+
+      assert {:ok, _} = LocalGit.write_files(request, repo_path: repo_path)
+      refute File.exists?(file_path)
+    end
+
+    test "returns explicit head mismatch", %{repo_path: repo_path} do
+      request = %{
+        message: "should fail",
+        branch: "main",
+        expected_head: String.duplicate("a", 40),
+        changes: [{:put, %{path: "DECISION.md", content: "x\n"}}]
+      }
+
+      assert {:error, {:expected_head_mismatch, _expected, actual}} =
+               LocalGit.write_files(request, repo_path: repo_path)
+
+      assert String.match?(actual, ~r/^[0-9a-f]{40}$/)
+    end
+
+    test "surfaces locked index clearly", %{repo_path: repo_path} do
+      lock_path = Path.join([repo_path, ".git", "index.lock"])
+      File.write!(lock_path, "")
+
+      request = %{
+        message: "should fail",
+        branch: "main",
+        expected_head: nil,
+        changes: [{:put, %{path: "DECISION.md", content: "x\n"}}]
+      }
+
+      assert {:error, {:index_locked, ^lock_path}} =
+               LocalGit.write_files(request, repo_path: repo_path)
+    end
+
+    test "surfaces push rejection clearly", %{repo_path: repo_path} do
+      remote_path = temp_path("roundtable-remote")
+      other_clone = temp_path("roundtable-other-clone")
+
+      File.rm_rf!(remote_path)
+      File.rm_rf!(other_clone)
+      File.mkdir_p!(remote_path)
+
+      git!(remote_path, ["init", "--bare"])
+      git!(repo_path, ["remote", "add", "origin", remote_path])
+      git!(repo_path, ["push", "-u", "origin", "main"])
+
+      git_system!(["clone", remote_path, other_clone])
+      git!(other_clone, ["config", "user.name", "Roundtable Test"])
+      git!(other_clone, ["config", "user.email", "roundtable@example.com"])
+
+      File.write!(Path.join(other_clone, "remote.txt"), "upstream change\n")
+      git!(other_clone, ["add", "remote.txt"])
+      git!(other_clone, ["commit", "-m", "upstream change"])
+      git!(other_clone, ["push", "origin", "main"])
+
+      {:ok, stale_head} = LocalGit.current_head("main", repo_path: repo_path)
+
+      request = %{
+        message: "local change",
+        branch: "main",
+        expected_head: stale_head,
+        changes: [{:put, %{path: "local.txt", content: "local change\n"}}]
+      }
+
+      assert {:error, {:push_rejected, output}} =
+               LocalGit.write_files(request, repo_path: repo_path, push?: true)
+
+      assert output =~ "rejected"
+
+      File.rm_rf!(remote_path)
+      File.rm_rf!(other_clone)
+    end
+  end
+
+  defp temp_path(prefix) do
+    Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
+  end
+
+  defp git!(repo_path, args) do
+    case System.cmd("git", args, cd: repo_path, stderr_to_stdout: true) do
+      {output, 0} -> output
+      {output, status} -> flunk("git #{Enum.join(args, " ")} failed (#{status}): #{output}")
+    end
+  end
+
+  defp git_system!(args) do
+    case System.cmd("git", args, stderr_to_stdout: true) do
+      {output, 0} -> output
+      {output, status} -> flunk("git #{Enum.join(args, " ")} failed (#{status}): #{output}")
+    end
+  end
+end

--- a/roundtable/test/roundtable/telemetry_test.exs
+++ b/roundtable/test/roundtable/telemetry_test.exs
@@ -90,7 +90,8 @@ defmodule Roundtable.TelemetryTest do
 
       Telemetry.satisfaction_parse(:gemini, "needs-more-evidence", :triage)
 
-      assert_receive {:telemetry, _, %{agent: :gemini, result: "needs-more-evidence", method: :triage}}
+      assert_receive {:telemetry, _,
+                      %{agent: :gemini, result: "needs-more-evidence", method: :triage}}
     end
   end
 
@@ -113,7 +114,11 @@ defmodule Roundtable.TelemetryTest do
       Telemetry.consensus_check(3, ["satisfied", "satisfied-conditional"], true)
 
       assert_receive {:telemetry, _,
-                      %{issue_number: 3, labels: ["satisfied", "satisfied-conditional"], result: true}}
+                      %{
+                        issue_number: 3,
+                        labels: ["satisfied", "satisfied-conditional"],
+                        result: true
+                      }}
     end
   end
 
@@ -159,7 +164,11 @@ defmodule Roundtable.TelemetryTest do
       Roundtable.RoundRun.put_phase(run, :triage_missing_markers)
 
       assert_receive {:telemetry, _,
-                      %{issue_number: 77_001, from_phase: :awaiting_turns, to_phase: :triage_missing_markers}}
+                      %{
+                        issue_number: 77_001,
+                        from_phase: :awaiting_turns,
+                        to_phase: :triage_missing_markers
+                      }}
     end
   end
 
@@ -222,6 +231,15 @@ defmodule Roundtable.TelemetryTest do
 
       assert output =~ "roundtable.issue.poll"
       assert output =~ "\"issue_number\":99"
+
+      :telemetry.detach("roundtable-json-logger")
+    end
+
+    test "is idempotent when called twice" do
+      :telemetry.detach("roundtable-json-logger")
+
+      assert :ok = Telemetry.attach_logger()
+      assert :ok = Telemetry.attach_logger()
 
       :telemetry.detach("roundtable-json-logger")
     end


### PR DESCRIPTION
Add standard GitHub funding metadata for Ko-fi.

- uses the GitHub-supported .github/FUNDING.yml location
- sets ko_fi to deepwatrcreatur


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added git-backed storage layer for persisting application state with file tracking and branch management capabilities.
  * Implemented local git integration supporting commit, read, and file operations.

* **Bug Fixes**
  * Fixed telemetry handler attachment to gracefully handle already-existing handlers.

* **Documentation**
  * Expanded development guide with telemetry event descriptions, span taxonomy, and setup instructions.

* **Tests**
  * Added comprehensive end-to-end tests for git storage operations.

* **Chores**
  * Updated project funding configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->