### PR TITLE
Recover Forgejo prototype dashboard/test slice

### DIFF
--- a/docs/work-items/66-forgejo-code-server-shell.md
+++ b/docs/work-items/66-forgejo-code-server-shell.md
@@ -1,6 +1,6 @@
 # 66 — Forgejo-Based Code Server Shell
 
-**Status:** `ready`
+**Status:** `done`
 **Tag:** `[product]`
 
 ## Goal
@@ -20,3 +20,15 @@ Stand up a Vaglio "code server" prototype that reuses Forgejo where it genuinely
 - A clear prototype architecture exists with explicit "reuse vs replace" boundaries.
 - The prototype can present a public repo through a Forgejo-based surface and link into Vaglio analysis views.
 - The chosen boundary does not assume Git must remain the long-term internal source of truth.
+
+## Outcome
+- Added a first deployable shell slice at `GET /forgejo-shell`.
+- Introduced `Roundtable.ForgejoShell` as the shell model that:
+  - builds Forgejo-edge navigation for a public repo
+  - makes Forgejo-owned vs Vaglio-owned boundaries explicit
+  - projects Git-shaped refs / PRs / merges into `jj`-native analysis payloads
+- Added `RoundtableWeb.ForgejoShellLive` so the prototype can:
+  - preview a Forgejo-backed public repo
+  - show Vaglio-native analysis on the same host
+  - keep Git compatibility at the edge instead of in the core model
+- Added focused model and LiveView tests for the shell surface.

--- a/docs/work-items/68-public-repo-investor-demo.md
+++ b/docs/work-items/68-public-repo-investor-demo.md
@@ -1,6 +1,6 @@
 # 68 — Public Repo Import & Investor Demo
 
-**Status:** `ready`
+**Status:** `done`
 **Tag:** `[market]`
 
 ## Goal
@@ -20,3 +20,16 @@ Build the minimum investor-facing prototype flow: import large public repositori
 - At least two substantial public repositories can be imported end-to-end.
 - The resulting dashboards are coherent enough for an investor demo.
 - The demo path reinforces Vaglio's product narrative rather than looking like generic repo analytics.
+
+## Outcome
+- Added `Roundtable.InvestorDemo` with curated public repo demo profiles:
+  - `NixOS/nixpkgs`
+  - `kubernetes/kubernetes`
+  - `forgejo/forgejo`
+- Wired the Forgejo shell page to import those profiles end-to-end into Forgejo-hosted demo targets such as `vaglio-demos/nixpkgs`.
+- Added investor-readable dashboard sections for:
+  - maintainer concentration
+  - contributor expertise signals
+  - subsystem hotspots
+  - provenance / deliberation overlays
+- Added focused tests for the demo catalog/import flow and updated the shell page test to cover the investor surface.

--- a/roundtable/lib/roundtable/tagging.ex
+++ b/roundtable/lib/roundtable/tagging.ex
@@ -5,32 +5,25 @@ defmodule Roundtable.Tagging do
   """
 
   alias Roundtable.Vcs.Dolt
+  alias Roundtable.Vcs.Jujutsu
 
   @doc """
   Add a tag to an issue.
   """
   def add_tag(repo_path, issue_id, tag_id, opts \\ []) do
     created_by = Keyword.get(opts, :created_by, "system")
-
+    
     # 1. Update Dolt (Relational Layer)
-    sql =
-      "INSERT IGNORE INTO issue_tags (issue_id, tag_id, created_by) VALUES ('#{issue_id}', '#{tag_id}', '#{created_by}')"
-
-    with {:ok, _} <- Dolt.query(sql, repo_path: repo_path),
-         {:ok, _} <-
-           Dolt.write_files(
-             %{
-               message: "feat(tag): add tag #{tag_id} to issue #{issue_id}",
-               branch: "main",
-               changes: []
-             },
-             repo_path: repo_path
-           ) do
+    sql = "INSERT IGNORE INTO issue_tags (issue_id, tag_id, created_by) VALUES ('#{issue_id}', '#{tag_id}', '#{created_by}')"
+    
+    with {:ok, _} <- Dolt.query(sql, [repo_path: repo_path]),
+         {:ok, _} <- Dolt.write_files(%{message: "feat(tag): add tag #{tag_id} to issue #{issue_id}", branch: "main", changes: []}, [repo_path: repo_path]) do
+      
       # 2. Update jj (Evolution Layer)
       # We represent tags as virtual bookmarks or description markers.
       # For now, we'll just log the protocol event.
       # In a real implementation, we might move a bookmark: tags/<tag_id>
-
+      
       :ok
     end
   end
@@ -40,17 +33,9 @@ defmodule Roundtable.Tagging do
   """
   def remove_tag(repo_path, issue_id, tag_id) do
     sql = "DELETE FROM issue_tags WHERE issue_id = '#{issue_id}' AND tag_id = '#{tag_id}'"
-
-    with {:ok, _} <- Dolt.query(sql, repo_path: repo_path),
-         {:ok, _} <-
-           Dolt.write_files(
-             %{
-               message: "feat(tag): remove tag #{tag_id} from issue #{issue_id}",
-               branch: "main",
-               changes: []
-             },
-             repo_path: repo_path
-           ) do
+    
+    with {:ok, _} <- Dolt.query(sql, [repo_path: repo_path]),
+         {:ok, _} <- Dolt.write_files(%{message: "feat(tag): remove tag #{tag_id} from issue #{issue_id}", branch: "main", changes: []}, [repo_path: repo_path]) do
       :ok
     end
   end
@@ -60,8 +45,8 @@ defmodule Roundtable.Tagging do
   """
   def list_issue_tags(repo_path, issue_id) do
     sql = "SELECT tag_id FROM issue_tags WHERE issue_id = '#{issue_id}'"
-
-    with {:ok, rows} <- Dolt.query(sql, repo_path: repo_path) do
+    
+    with {:ok, rows} <- Dolt.query(sql, [repo_path: repo_path]) do
       {:ok, Enum.map(rows, & &1["tag_id"])}
     end
   end
@@ -71,8 +56,8 @@ defmodule Roundtable.Tagging do
   """
   def list_tagged_issues(repo_path, tag_id) do
     sql = "SELECT issue_id FROM issue_tags WHERE tag_id = '#{tag_id}'"
-
-    with {:ok, rows} <- Dolt.query(sql, repo_path: repo_path) do
+    
+    with {:ok, rows} <- Dolt.query(sql, [repo_path: repo_path]) do
       {:ok, Enum.map(rows, & &1["issue_id"])}
     end
   end

--- a/roundtable/lib/roundtable/tagging.ex
+++ b/roundtable/lib/roundtable/tagging.ex
@@ -5,25 +5,32 @@ defmodule Roundtable.Tagging do
   """
 
   alias Roundtable.Vcs.Dolt
-  alias Roundtable.Vcs.Jujutsu
 
   @doc """
   Add a tag to an issue.
   """
   def add_tag(repo_path, issue_id, tag_id, opts \\ []) do
     created_by = Keyword.get(opts, :created_by, "system")
-    
+
     # 1. Update Dolt (Relational Layer)
-    sql = "INSERT IGNORE INTO issue_tags (issue_id, tag_id, created_by) VALUES ('#{issue_id}', '#{tag_id}', '#{created_by}')"
-    
-    with {:ok, _} <- Dolt.query(sql, [repo_path: repo_path]),
-         {:ok, _} <- Dolt.write_files(%{message: "feat(tag): add tag #{tag_id} to issue #{issue_id}", branch: "main", changes: []}, [repo_path: repo_path]) do
-      
+    sql =
+      "INSERT IGNORE INTO issue_tags (issue_id, tag_id, created_by) VALUES ('#{issue_id}', '#{tag_id}', '#{created_by}')"
+
+    with {:ok, _} <- Dolt.query(sql, repo_path: repo_path),
+         {:ok, _} <-
+           Dolt.write_files(
+             %{
+               message: "feat(tag): add tag #{tag_id} to issue #{issue_id}",
+               branch: "main",
+               changes: []
+             },
+             repo_path: repo_path
+           ) do
       # 2. Update jj (Evolution Layer)
       # We represent tags as virtual bookmarks or description markers.
       # For now, we'll just log the protocol event.
       # In a real implementation, we might move a bookmark: tags/<tag_id>
-      
+
       :ok
     end
   end
@@ -33,9 +40,17 @@ defmodule Roundtable.Tagging do
   """
   def remove_tag(repo_path, issue_id, tag_id) do
     sql = "DELETE FROM issue_tags WHERE issue_id = '#{issue_id}' AND tag_id = '#{tag_id}'"
-    
-    with {:ok, _} <- Dolt.query(sql, [repo_path: repo_path]),
-         {:ok, _} <- Dolt.write_files(%{message: "feat(tag): remove tag #{tag_id} from issue #{issue_id}", branch: "main", changes: []}, [repo_path: repo_path]) do
+
+    with {:ok, _} <- Dolt.query(sql, repo_path: repo_path),
+         {:ok, _} <-
+           Dolt.write_files(
+             %{
+               message: "feat(tag): remove tag #{tag_id} from issue #{issue_id}",
+               branch: "main",
+               changes: []
+             },
+             repo_path: repo_path
+           ) do
       :ok
     end
   end
@@ -45,8 +60,8 @@ defmodule Roundtable.Tagging do
   """
   def list_issue_tags(repo_path, issue_id) do
     sql = "SELECT tag_id FROM issue_tags WHERE issue_id = '#{issue_id}'"
-    
-    with {:ok, rows} <- Dolt.query(sql, [repo_path: repo_path]) do
+
+    with {:ok, rows} <- Dolt.query(sql, repo_path: repo_path) do
       {:ok, Enum.map(rows, & &1["tag_id"])}
     end
   end
@@ -56,8 +71,8 @@ defmodule Roundtable.Tagging do
   """
   def list_tagged_issues(repo_path, tag_id) do
     sql = "SELECT issue_id FROM issue_tags WHERE tag_id = '#{tag_id}'"
-    
-    with {:ok, rows} <- Dolt.query(sql, [repo_path: repo_path]) do
+
+    with {:ok, rows} <- Dolt.query(sql, repo_path: repo_path) do
       {:ok, Enum.map(rows, & &1["issue_id"])}
     end
   end

--- a/roundtable/lib/roundtable_web/endpoint.ex
+++ b/roundtable/lib/roundtable_web/endpoint.ex
@@ -7,19 +7,34 @@ defmodule RoundtableWeb.Endpoint do
     signing_salt: "roundtable_session_salt"
   ]
 
-  socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
+  socket("/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]])
 
-  plug Plug.Static,
+  plug(Plug.Static,
+    at: "/vendor/phoenix",
+    from: {:phoenix, "priv/static"},
+    gzip: false,
+    only: ~w(phoenix.js phoenix.min.js)
+  )
+
+  plug(Plug.Static,
+    at: "/vendor/phoenix_live_view",
+    from: {:phoenix_live_view, "priv/static"},
+    gzip: false,
+    only: ~w(phoenix_live_view.js phoenix_live_view.min.js)
+  )
+
+  plug(Plug.Static,
     at: "/",
     from: :roundtable,
     gzip: false,
     only: ~w(assets fonts images favicon.ico robots.txt)
+  )
 
-  plug Plug.RequestId
-  plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
-  plug Plug.Parsers, parsers: [:urlencoded, :multipart, :json], json_decoder: Jason
-  plug Plug.MethodOverride
-  plug Plug.Head
-  plug Plug.Session, @session_options
-  plug RoundtableWeb.Router
+  plug(Plug.RequestId)
+  plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
+  plug(Plug.Parsers, parsers: [:urlencoded, :multipart, :json], json_decoder: Jason)
+  plug(Plug.MethodOverride)
+  plug(Plug.Head)
+  plug(Plug.Session, @session_options)
+  plug(RoundtableWeb.Router)
 end

--- a/roundtable/lib/roundtable_web/error_html.ex
+++ b/roundtable/lib/roundtable_web/error_html.ex
@@ -1,0 +1,7 @@
+defmodule RoundtableWeb.ErrorHTML do
+  use Phoenix.Component
+
+  def render(_template, _assigns) do
+    "Something went wrong"
+  end
+end

--- a/roundtable/lib/roundtable_web/error_html.ex
+++ b/roundtable/lib/roundtable_web/error_html.ex
@@ -1,6 +1,10 @@
 defmodule RoundtableWeb.ErrorHTML do
   use Phoenix.Component
 
+  def render("401.html", _assigns), do: "Unauthorized"
+  def render("404.html", _assigns), do: "Page not found"
+  def render("500.html", _assigns), do: "Internal server error"
+
   def render(_template, _assigns) do
     "Something went wrong"
   end

--- a/roundtable/lib/roundtable_web/layouts.ex
+++ b/roundtable/lib/roundtable_web/layouts.ex
@@ -8,6 +8,7 @@ defmodule RoundtableWeb.Layouts do
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="csrf-token" content={Phoenix.Controller.get_csrf_token()} />
         <title>Roundtable</title>
         <style>
           *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -15,8 +16,37 @@ defmodule RoundtableWeb.Layouts do
                  background: #0d1117; color: #c9d1d9; min-height: 100vh; }
           a { color: #58a6ff; }
         </style>
+        <script defer src="/vendor/phoenix/phoenix.min.js"></script>
+        <script defer src="/vendor/phoenix_live_view/phoenix_live_view.min.js"></script>
+        <script defer>
+          window.addEventListener("DOMContentLoaded", () => {
+            const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content")
+
+            if (window.Phoenix && window.LiveView && !window.liveSocket) {
+              const liveSocket = new window.LiveView.LiveSocket("/live", window.Phoenix.Socket, {
+                params: { _csrf_token: csrfToken }
+              })
+
+              liveSocket.connect()
+              window.liveSocket = liveSocket
+            }
+          })
+        </script>
       </head>
       <body>
+        <nav style="border-bottom: 1px solid #21262d; background: #0d1117; position: sticky; top: 0; z-index: 10;">
+          <div style="max-width: 1100px; margin: 0 auto; padding: 0.85rem 1rem; display: flex; gap: 0.75rem; align-items: center; justify-content: space-between;">
+            <div style="color: #f0f6fc; font-weight: 700; font-size: 0.95rem;">Deepwater Roundtable</div>
+            <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+              <a href="/" style="text-decoration: none; color: #c9d1d9; border: 1px solid #30363d; border-radius: 999px; padding: 0.35rem 0.75rem; font-size: 0.82rem;">
+                Roundtable Dashboard · discussion ops
+              </a>
+              <a href="/forgejo-shell" style="text-decoration: none; color: #c9d1d9; border: 1px solid #30363d; border-radius: 999px; padding: 0.35rem 0.75rem; font-size: 0.82rem;">
+                Forgejo Demo Shell · investor demo
+              </a>
+            </div>
+          </div>
+        </nav>
         {@inner_content}
       </body>
     </html>

--- a/roundtable/lib/roundtable_web/live/discussion_live.ex
+++ b/roundtable/lib/roundtable_web/live/discussion_live.ex
@@ -309,6 +309,10 @@ defmodule RoundtableWeb.DiscussionLive do
           Discussion Source
         </h2>
 
+        <p style="color: #8b949e; font-size: 0.82rem; line-height: 1.5; margin-bottom: 0.9rem;">
+          Click a repo card to select it immediately. The selected repo and default discussion path will populate below without needing the Apply button.
+        </p>
+
         <div :if={length(@candidate_repos) > 0} style="display: grid; gap: 0.75rem; margin-bottom: 1rem;">
           <button
             :for={candidate <- @candidate_repos}
@@ -320,6 +324,9 @@ defmodule RoundtableWeb.DiscussionLive do
           >
             <span style="display: block; font-size: 0.95rem; font-weight: 600; color: #f0f6fc;">
               {candidate.slug}
+              <span :if={candidate.slug == @repo} style="margin-left: 0.45rem; color: #58a6ff; font-size: 0.75rem; text-transform: uppercase;">
+                selected
+              </span>
             </span>
             <span :if={candidate.description} style="display: block; margin-top: 0.35rem; color: #8b949e; font-size: 0.82rem;">
               {candidate.description}
@@ -328,6 +335,25 @@ defmodule RoundtableWeb.DiscussionLive do
               {candidate_topic_line(candidate)}
             </span>
           </button>
+        </div>
+
+        <div
+          :if={@source_mode == "repo" and blank_to_nil(@repo)}
+          style="background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 0.85rem 1rem; margin-bottom: 1rem;"
+        >
+          <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase; margin-bottom: 0.35rem;">
+            Active discussion target
+          </div>
+          <div style="color: #f0f6fc; font-weight: 600;">
+            {@repo}
+          </div>
+          <div style="color: #8b949e; font-size: 0.82rem; margin-top: 0.35rem; line-height: 1.5;">
+            Discussion path:
+            <strong style="color: #c9d1d9; font-weight: 600;">
+              {if blank_to_nil(@discussion_path), do: @discussion_path, else: "(repo root)"}
+            </strong>
+            . New questions and round state will be read from and written to this repo/path.
+          </div>
         </div>
 
         <form phx-submit="set_source" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.75rem; align-items: end; margin-bottom: 0.5rem;">
@@ -340,23 +366,35 @@ defmodule RoundtableWeb.DiscussionLive do
           </label>
 
           <label style="display: flex; flex-direction: column; gap: 0.35rem; color: #8b949e; font-size: 0.8rem;">
-            GitHub repo
+            Discussion repo
             <input type="text" name="repo" value={@repo} placeholder="owner/repo" style={input_style()} />
+            <span style="color: #8b949e; font-size: 0.74rem; line-height: 1.4;">
+              The remote repo where roundtable files and issue-backed discussion state live.
+            </span>
           </label>
 
           <label style="display: flex; flex-direction: column; gap: 0.35rem; color: #8b949e; font-size: 0.8rem;">
             Discussion path
             <input type="text" name="discussion_path" value={@discussion_path} placeholder="repo root or embedded folder" style={input_style()} />
+            <span style="color: #8b949e; font-size: 0.74rem; line-height: 1.4;">
+              Optional folder inside the discussion repo, such as <code style="color: #c9d1d9;">docs/design</code>.
+            </span>
           </label>
 
           <label style="display: flex; flex-direction: column; gap: 0.35rem; color: #8b949e; font-size: 0.8rem;">
             Legacy BRIEF path
             <input type="text" name="brief_path" value={@brief_path} placeholder="docs/design/BRIEF.md" style={input_style()} />
+            <span style="color: #8b949e; font-size: 0.74rem; line-height: 1.4;">
+              Used only in legacy BRIEF-file mode instead of repo-backed discussions.
+            </span>
           </label>
 
           <label style="display: flex; flex-direction: column; gap: 0.35rem; color: #8b949e; font-size: 0.8rem;">
             Local checkout
             <input type="text" name="local_path" value={@local_path} placeholder="/path/to/repo" style={input_style()} />
+            <span style="color: #8b949e; font-size: 0.74rem; line-height: 1.4;">
+              Local clone used for conflict inspection and resolve actions. It does not decide which remote repo receives discussion updates.
+            </span>
           </label>
 
           <button type="submit" style={btn_style(:primary)}>Apply</button>

--- a/roundtable/test/roundtable/cli_test.exs
+++ b/roundtable/test/roundtable/cli_test.exs
@@ -3,6 +3,11 @@ defmodule Roundtable.CLITest do
 
   alias Roundtable.CLI
 
+  setup_all do
+    assert Code.ensure_loaded?(CLI)
+    :ok
+  end
+
   setup do
     brief_path = Path.join(System.tmp_dir!(), "test_brief_cli_#{System.unique_integer()}.md")
     File.write!(brief_path, "# Brief\n\n### Q1 — Architecture\n\nWhat should we build?\n")

--- a/roundtable/test/roundtable_web/discussion_live_test.exs
+++ b/roundtable/test/roundtable_web/discussion_live_test.exs
@@ -1,0 +1,88 @@
+defmodule RoundtableWeb.DiscussionLiveTest do
+  use ExUnit.Case, async: true
+  import Phoenix.Component
+  import Phoenix.LiveViewTest
+
+  alias RoundtableWeb.DiscussionLive
+
+  test "select_candidate_repo populates repo and discussion path" do
+    socket =
+      %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}}}
+      |> assign(:candidate_repos, [
+        %{
+          slug: "deepwatrcreatur/agent-roundtable",
+          description: "Roundtable repo",
+          private: false,
+          url: "https://github.com/deepwatrcreatur/agent-roundtable",
+          topics: ["discussion", "embedded"]
+        }
+      ])
+      |> assign(:repo, "")
+      |> assign(:discussion_path, "")
+      |> assign(:source_mode, "brief")
+      |> assign(:local_path, "")
+      |> assign(:questions, %{})
+      |> assign(:conflicts, [])
+
+    assert {:noreply, updated} =
+             DiscussionLive.handle_event(
+               "select_candidate_repo",
+               %{"repo" => "deepwatrcreatur/agent-roundtable"},
+               socket
+             )
+
+    assert updated.assigns.repo == "deepwatrcreatur/agent-roundtable"
+    assert updated.assigns.discussion_path == "docs/design"
+    assert updated.assigns.source_mode == "repo"
+    assert updated.assigns.flash_msg == "Selected deepwatrcreatur/agent-roundtable"
+  end
+
+  test "render explains discussion path and local checkout roles" do
+    assigns = %{
+      __changed__: %{},
+      repo: "deepwatrcreatur/agent-roundtable",
+      brief_path: "docs/design/BRIEF.md",
+      local_path: "/tmp/agent-roundtable",
+      discussion_path: "docs/design",
+      source_mode: "repo",
+      candidate_repos: [
+        %{
+          slug: "deepwatrcreatur/agent-roundtable",
+          description: "Roundtable repo",
+          private: false,
+          url: "https://github.com/deepwatrcreatur/agent-roundtable",
+          topics: ["discussion", "embedded"]
+        }
+      ],
+      inject_text: "",
+      running: false,
+      flash_msg: nil,
+      conflicts: [],
+      questions: %{},
+      robustness_meters: %{},
+      low_robustness_history: [],
+      integrity_scorecard: %{},
+      red_team_only: false,
+      red_team_views: %{},
+      provenance_views: %{},
+      anchor_statuses: %{},
+      maintainer_options: ["maintainer@example.com"],
+      selected_maintainer: "maintainer@example.com"
+    }
+
+    html =
+      assigns
+      |> DiscussionLive.render()
+      |> rendered_to_string()
+
+    assert html =~ "Active discussion target"
+    assert html =~ "Discussion path:"
+
+    assert html =~
+             "The remote repo where roundtable files and issue-backed discussion state live."
+
+    assert html =~ "Optional folder inside the discussion repo"
+    assert html =~ "Local clone used for conflict inspection and resolve actions."
+    assert html =~ "does not decide which remote repo receives discussion updates"
+  end
+end

--- a/roundtable/test/roundtable_web/forgejo_shell_live_test.exs
+++ b/roundtable/test/roundtable_web/forgejo_shell_live_test.exs
@@ -1,11 +1,15 @@
 defmodule RoundtableWeb.ForgejoShellLiveTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Phoenix.ConnTest
 
   @endpoint RoundtableWeb.Endpoint
 
   setup_all do
-    start_supervised!(RoundtableWeb.Endpoint)
+    case start_supervised(RoundtableWeb.Endpoint) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
     :ok
   end
 
@@ -13,6 +17,11 @@ defmodule RoundtableWeb.ForgejoShellLiveTest do
     conn = get(build_conn(), "/forgejo-shell")
     html = html_response(conn, 200)
 
+    assert html =~ "/vendor/phoenix/phoenix.min.js"
+    assert html =~ "/vendor/phoenix_live_view/phoenix_live_view.min.js"
+    assert html =~ "Deepwater Roundtable"
+    assert html =~ "Roundtable Dashboard · discussion ops"
+    assert html =~ "Forgejo Demo Shell · investor demo"
     assert html =~ "Forgejo Code Server Shell"
     assert html =~ "Curated Investor Demos"
     assert html =~ "NixOS/nixpkgs"

--- a/roundtable/test/roundtable_web/navigation_test.exs
+++ b/roundtable/test/roundtable_web/navigation_test.exs
@@ -1,0 +1,35 @@
+defmodule RoundtableWeb.NavigationTest do
+  use ExUnit.Case, async: false
+  import Phoenix.ConnTest
+
+  @endpoint RoundtableWeb.Endpoint
+
+  setup_all do
+    case start_supervised(RoundtableWeb.Endpoint) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
+    :ok
+  end
+
+  test "roundtable dashboard includes shared navigation" do
+    conn = get(build_conn(), "/")
+    html = html_response(conn, 200)
+
+    assert html =~ "Deepwater Roundtable"
+    assert html =~ "Roundtable Dashboard · discussion ops"
+    assert html =~ "Forgejo Demo Shell · investor demo"
+    assert html =~ "href=\"/forgejo-shell\""
+  end
+
+  test "forgejo shell includes shared navigation" do
+    conn = get(build_conn(), "/forgejo-shell")
+    html = html_response(conn, 200)
+
+    assert html =~ "Deepwater Roundtable"
+    assert html =~ "Roundtable Dashboard · discussion ops"
+    assert html =~ "Forgejo Demo Shell · investor demo"
+    assert html =~ "href=\"/\""
+  end
+end


### PR DESCRIPTION
## Summary
- recover the remaining Forgejo prototype dashboard/doc/test changes that were still only local
- update the recovered work-item docs for items 66 and 68 to their completed state
- add the rebased DiscussionLive and navigation test coverage needed for the current dashboard shape

## Testing
- nix develop .#default --command mix test test/roundtable/adapters/forgejo_test.exs test/roundtable/translation/git_to_jj_test.exs test/roundtable/forgejo_shell_test.exs test/roundtable/investor_demo_test.exs test/roundtable/architecture_benchmark_test.exs test/roundtable_web/forgejo_shell_live_test.exs test/roundtable_web/navigation_test.exs test/roundtable_web/discussion_live_test.exs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched Forgejo shell interface accessible from the dashboard
  * Added investor demo with curated public repository profiles and analytics dashboard (maintainer concentration, contributor expertise, subsystem analysis)
  * Enhanced discussion source selection UI with active target display and clearer configuration options
  * Improved navigation between dashboard and shell pages

* **Documentation**
  * Updated work item documentation marking Forgejo shell and investor demo as complete with outcome descriptions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/agent-roundtable/pull/77)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->