### PR TITLE
Recover Authentik OIDC dashboard auth

### DIFF
--- a/docs/work-items/25-authentik-oidc.md
+++ b/docs/work-items/25-authentik-oidc.md
@@ -1,7 +1,7 @@
 # 25 — Authentik OIDC Authentication
 
-**Status:** `ready`
-**Assigned:** Gemini
+**Status:** `in-progress`
+**Assigned:** Codex
 
 ## Scope
 

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -45,7 +45,7 @@ Do not work on an item already marked `in-progress` by another agent.
 16. [`19-orchestrator-repo-path.md`](./19-orchestrator-repo-path.md) — `done` — Orchestrator file-based model integration
 17. [`23-no-objection-marker.md`](./23-no-objection-marker.md) — `done` — `[no objection]` satisfaction marker support
 18. [`24-telegram-outbound.md`](./24-telegram-outbound.md) — `done` — Outbound Telegram notifications
-19. [`25-authentik-oidc.md`](./25-authentik-oidc.md) — `done` — Authentik OIDC authentication
+19. [`25-authentik-oidc.md`](./25-authentik-oidc.md) — `in-progress` — **Codex** — Authentik OIDC authentication
 20. [`26-nixos-module.md`](./26-nixos-module.md) — `done` — **Gemini** — NixOS service module & deployment config
 
 ### Eval Harness (Q37 / Round 22)

--- a/roundtable/lib/roundtable/auth.ex
+++ b/roundtable/lib/roundtable/auth.ex
@@ -15,7 +15,8 @@ defmodule Roundtable.Auth do
 
   def authorization_url(state, redirect_uri) do
     with :ok <- ensure_enabled(),
-         {:ok, metadata} <- discovery_document() do
+         {:ok, metadata} <- discovery_document(),
+         {:ok, %{authorization_endpoint: authorization_endpoint}} <- endpoint_metadata(metadata) do
       params = %{
         "client_id" => client_id(),
         "redirect_uri" => redirect_uri,
@@ -24,15 +25,18 @@ defmodule Roundtable.Auth do
         "state" => state
       }
 
-      {:ok, metadata["authorization_endpoint"] <> "?" <> URI.encode_query(params)}
+      {:ok, authorization_endpoint <> "?" <> URI.encode_query(params)}
     end
   end
 
   def exchange_code_for_user(code, redirect_uri) do
     with :ok <- ensure_enabled(),
          {:ok, metadata} <- discovery_document(),
-         {:ok, tokens} <- exchange_code(metadata["token_endpoint"], code, redirect_uri),
-         {:ok, userinfo} <- fetch_userinfo(metadata["userinfo_endpoint"], tokens["access_token"]),
+         {:ok, %{token_endpoint: token_endpoint, userinfo_endpoint: userinfo_endpoint}} <-
+           endpoint_metadata(metadata),
+         {:ok, tokens} <- exchange_code(token_endpoint, code, redirect_uri),
+         {:ok, access_token} <- access_token(tokens),
+         {:ok, userinfo} <- fetch_userinfo(userinfo_endpoint, access_token),
          {:ok, current_user} <- normalize_user(userinfo) do
       {:ok, current_user}
     end
@@ -48,15 +52,9 @@ defmodule Roundtable.Auth do
         {:error, :missing_service_pat}
 
       token ->
-        url = "#{@github_api}/repos/#{repo}/collaborators/#{github_login}/permission"
-
-        headers = [
-          {"authorization", "Bearer #{token}"},
-          {"accept", "application/vnd.github+json"},
-          {"x-github-api-version", "2022-11-28"}
-        ]
-
-        with {:ok, %{status: 200, body: body}} <- request(:get, url, headers: headers) do
+        with {:ok, url} <- repo_permission_url(repo, github_login),
+             {:ok, %{status: 200, body: body}} <- request(:get, url, headers: github_headers(token)),
+             true <- is_map(body) or {:error, {:unexpected_github_body, body}} do
           permission = String.downcase(body["permission"] || "")
           {:ok, permission in @read_permissions}
         else
@@ -141,6 +139,28 @@ defmodule Roundtable.Auth do
     if enabled?(), do: :ok, else: {:error, :oidc_disabled}
   end
 
+  defp endpoint_metadata(metadata) when is_map(metadata) do
+    with authz when is_binary(authz) and authz != "" <- metadata["authorization_endpoint"],
+         token when is_binary(token) and token != "" <- metadata["token_endpoint"],
+         userinfo when is_binary(userinfo) and userinfo != "" <- metadata["userinfo_endpoint"] do
+      {:ok,
+       %{
+         authorization_endpoint: authz,
+         token_endpoint: token,
+         userinfo_endpoint: userinfo
+       }}
+    else
+      _ -> {:error, :missing_oidc_metadata}
+    end
+  end
+
+  defp endpoint_metadata(_), do: {:error, :missing_oidc_metadata}
+
+  defp access_token(%{"access_token" => token}) when is_binary(token) and token != "",
+    do: {:ok, token}
+
+  defp access_token(_), do: {:error, :missing_access_token}
+
   defp issuer_url do
     config_value(:issuer_url, "OIDC_ISSUER_URL")
     |> to_string()
@@ -173,20 +193,70 @@ defmodule Roundtable.Auth do
     Keyword.get(config, key) || System.get_env(env_var) || ""
   end
 
-  defp request(method, url, opts \\ []) do
-    case Keyword.get(Application.get_env(:roundtable, __MODULE__, []), :http_client) do
-      fun when is_function(fun, 3) ->
-        fun.(method, url, opts)
+  defp github_headers(token) do
+    [
+      {"authorization", "Bearer #{token}"},
+      {"accept", "application/vnd.github+json"},
+      {"x-github-api-version", "2022-11-28"}
+    ]
+  end
+
+  defp repo_permission_url(repo, github_login) do
+    with {:ok, {owner, name}} <- split_repo_slug(repo),
+         {:ok, encoded_login} <- encode_github_login(github_login) do
+      {:ok, "#{@github_api}/repos/#{owner}/#{name}/collaborators/#{encoded_login}/permission"}
+    end
+  end
+
+  defp split_repo_slug(repo) do
+    case String.split(to_string(repo), "/", parts: 2) do
+      [owner, name] ->
+        owner = String.trim(owner)
+        name = String.trim(name)
+
+        if valid_repo_segment?(owner) and valid_repo_segment?(name) do
+          {:ok, {URI.encode(owner, &URI.char_unreserved?/1), URI.encode(name, &URI.char_unreserved?/1)}}
+        else
+          {:error, :invalid_repo}
+        end
 
       _ ->
-        request_opts =
-          [method: method, url: url, headers: Keyword.get(opts, :headers, [])]
-          |> maybe_put(:form, Keyword.get(opts, :form))
+        {:error, :invalid_repo}
+    end
+  end
 
-        case Req.request(request_opts) do
-          {:ok, %Req.Response{status: status, body: body}} -> {:ok, %{status: status, body: body}}
-          {:error, reason} -> {:error, reason}
-        end
+  defp encode_github_login(github_login) do
+    login = github_login |> to_string() |> String.trim()
+
+    if Regex.match?(~r/\A[a-zA-Z0-9-]+\z/, login) do
+      {:ok, URI.encode(login, &URI.char_unreserved?/1)}
+    else
+      {:error, :invalid_github_login}
+    end
+  end
+
+  defp valid_repo_segment?(segment) do
+    segment != "" and Regex.match?(~r/\A[A-Za-z0-9._-]+\z/, segment)
+  end
+
+  defp request(method, url, opts \\ []) do
+    if not is_binary(url) or url == "" do
+      {:error, :invalid_url}
+    else
+      case Keyword.get(Application.get_env(:roundtable, __MODULE__, []), :http_client) do
+        fun when is_function(fun, 3) ->
+          fun.(method, url, opts)
+
+        _ ->
+          request_opts =
+            [method: method, url: url, headers: Keyword.get(opts, :headers, [])]
+            |> maybe_put(:form, Keyword.get(opts, :form))
+
+          case Req.request(request_opts) do
+            {:ok, %Req.Response{status: status, body: body}} -> {:ok, %{status: status, body: body}}
+            {:error, reason} -> {:error, reason}
+          end
+      end
     end
   end
 

--- a/roundtable/lib/roundtable/auth.ex
+++ b/roundtable/lib/roundtable/auth.ex
@@ -1,0 +1,195 @@
+defmodule Roundtable.Auth do
+  @moduledoc """
+  Minimal OIDC and GitHub access helpers for the Vaglio web UI.
+
+  When `OIDC_ISSUER_URL` is unset, the dashboard remains in unauthenticated
+  mode for local development.
+  """
+
+  @github_api "https://api.github.com"
+  @read_permissions ~w(admin maintain write triage read)
+
+  def enabled? do
+    issuer_url() != ""
+  end
+
+  def authorization_url(state, redirect_uri) do
+    with :ok <- ensure_enabled(),
+         {:ok, metadata} <- discovery_document() do
+      params = %{
+        "client_id" => client_id(),
+        "redirect_uri" => redirect_uri,
+        "response_type" => "code",
+        "scope" => "openid profile email",
+        "state" => state
+      }
+
+      {:ok, metadata["authorization_endpoint"] <> "?" <> URI.encode_query(params)}
+    end
+  end
+
+  def exchange_code_for_user(code, redirect_uri) do
+    with :ok <- ensure_enabled(),
+         {:ok, metadata} <- discovery_document(),
+         {:ok, tokens} <- exchange_code(metadata["token_endpoint"], code, redirect_uri),
+         {:ok, userinfo} <- fetch_userinfo(metadata["userinfo_endpoint"], tokens["access_token"]),
+         {:ok, current_user} <- normalize_user(userinfo) do
+      {:ok, current_user}
+    end
+  end
+
+  def repo_readable_by?(repo, github_login) when repo in [nil, ""] or github_login in [nil, ""] do
+    {:error, :missing_repo_or_login}
+  end
+
+  def repo_readable_by?(repo, github_login) do
+    case service_token() do
+      nil ->
+        {:error, :missing_service_pat}
+
+      token ->
+        url = "#{@github_api}/repos/#{repo}/collaborators/#{github_login}/permission"
+
+        headers = [
+          {"authorization", "Bearer #{token}"},
+          {"accept", "application/vnd.github+json"},
+          {"x-github-api-version", "2022-11-28"}
+        ]
+
+        with {:ok, %{status: 200, body: body}} <- request(:get, url, headers: headers) do
+          permission = String.downcase(body["permission"] || "")
+          {:ok, permission in @read_permissions}
+        else
+          {:ok, %{status: 404}} -> {:ok, false}
+          {:ok, %{status: 403}} -> {:error, :github_forbidden}
+          {:ok, %{status: status, body: body}} -> {:error, {:unexpected_github_status, status, body}}
+          {:error, _} = err -> err
+        end
+    end
+  end
+
+  def filter_accessible_repos(repos, nil), do: repos
+
+  def filter_accessible_repos(repos, github_login) do
+    Enum.filter(repos, fn repo ->
+      case repo_readable_by?(repo.slug, github_login) do
+        {:ok, true} -> true
+        _ -> false
+      end
+    end)
+  end
+
+  defp normalize_user(userinfo) do
+    github_login =
+      userinfo["preferred_username"] ||
+        userinfo["nickname"] ||
+        userinfo["username"] ||
+        userinfo["sub"]
+
+    if is_binary(github_login) and github_login != "" do
+      {:ok,
+       %{
+         "github_login" => github_login,
+         "email" => userinfo["email"],
+         "name" => userinfo["name"]
+       }}
+    else
+      {:error, :missing_github_login_claim}
+    end
+  end
+
+  defp exchange_code(token_endpoint, code, redirect_uri) do
+    form = [
+      grant_type: "authorization_code",
+      code: code,
+      redirect_uri: redirect_uri,
+      client_id: client_id(),
+      client_secret: client_secret()
+    ]
+
+    with {:ok, %{status: 200, body: body}} <- request(:post, token_endpoint, form: form) do
+      {:ok, body}
+    else
+      {:ok, %{status: status, body: body}} -> {:error, {:token_exchange_failed, status, body}}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp fetch_userinfo(userinfo_endpoint, access_token) do
+    headers = [{"authorization", "Bearer #{access_token}"}]
+
+    with {:ok, %{status: 200, body: body}} <- request(:get, userinfo_endpoint, headers: headers) do
+      {:ok, body}
+    else
+      {:ok, %{status: status, body: body}} -> {:error, {:userinfo_failed, status, body}}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp discovery_document do
+    url = issuer_url() <> "/.well-known/openid-configuration"
+
+    with {:ok, %{status: 200, body: body}} <- request(:get, url) do
+      {:ok, body}
+    else
+      {:ok, %{status: status, body: body}} -> {:error, {:discovery_failed, status, body}}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp ensure_enabled do
+    if enabled?(), do: :ok, else: {:error, :oidc_disabled}
+  end
+
+  defp issuer_url do
+    config_value(:issuer_url, "OIDC_ISSUER_URL")
+    |> to_string()
+    |> String.trim()
+    |> String.trim_trailing("/")
+  end
+
+  defp client_id do
+    config_value(:client_id, "OIDC_CLIENT_ID")
+    |> to_string()
+  end
+
+  defp client_secret do
+    config_value(:client_secret, "OIDC_CLIENT_SECRET")
+    |> to_string()
+  end
+
+  defp service_token do
+    env = System.get_env("GITHUB_SERVICE_PAT") || System.get_env("GH_TOKEN")
+
+    case String.trim(env || "") do
+      "" -> nil
+      token -> token
+    end
+  end
+
+  defp config_value(key, env_var) do
+    config = Application.get_env(:roundtable, __MODULE__, [])
+
+    Keyword.get(config, key) || System.get_env(env_var) || ""
+  end
+
+  defp request(method, url, opts \\ []) do
+    case Keyword.get(Application.get_env(:roundtable, __MODULE__, []), :http_client) do
+      fun when is_function(fun, 3) ->
+        fun.(method, url, opts)
+
+      _ ->
+        request_opts =
+          [method: method, url: url, headers: Keyword.get(opts, :headers, [])]
+          |> maybe_put(:form, Keyword.get(opts, :form))
+
+        case Req.request(request_opts) do
+          {:ok, %Req.Response{status: status, body: body}} -> {:ok, %{status: status, body: body}}
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+end

--- a/roundtable/lib/roundtable_web/auth_controller.ex
+++ b/roundtable/lib/roundtable_web/auth_controller.ex
@@ -60,13 +60,9 @@ defmodule RoundtableWeb.AuthController do
     |> redirect(to: "/")
   end
 
-  defp redirect_uri(conn) do
-    %URI{
-      scheme: Atom.to_string(conn.scheme),
-      host: conn.host,
-      port: conn.port,
-      path: "/auth/callback"
-    }
+  defp redirect_uri(_conn) do
+    RoundtableWeb.Endpoint.url()
+    |> URI.merge("/auth/callback")
     |> URI.to_string()
   end
 

--- a/roundtable/lib/roundtable_web/auth_controller.ex
+++ b/roundtable/lib/roundtable_web/auth_controller.ex
@@ -1,0 +1,81 @@
+defmodule RoundtableWeb.AuthController do
+  use Phoenix.Controller, namespace: RoundtableWeb
+
+  import Plug.Conn
+
+  alias Roundtable.Auth
+
+  def sign_in(conn, _params) do
+    if Auth.enabled?() do
+      state = random_state()
+      conn = put_session(conn, :oidc_state, state)
+
+      case Auth.authorization_url(state, redirect_uri(conn)) do
+        {:ok, url} ->
+          redirect(conn, external: url)
+
+        {:error, reason} ->
+          conn
+          |> put_flash(:error, "OIDC sign-in failed: #{format_reason(reason)}")
+          |> redirect(to: "/")
+      end
+    else
+      redirect(conn, to: "/")
+    end
+  end
+
+  def callback(conn, %{"code" => code, "state" => state}) do
+    if get_session(conn, :oidc_state) == state do
+      case Auth.exchange_code_for_user(code, redirect_uri(conn)) do
+        {:ok, current_user} ->
+          conn
+          |> configure_session(renew: true)
+          |> delete_session(:oidc_state)
+          |> put_session(:current_user, current_user)
+          |> redirect(to: "/")
+
+        {:error, reason} ->
+          conn
+          |> configure_session(drop: true)
+          |> put_flash(:error, "OIDC callback failed: #{format_reason(reason)}")
+          |> redirect(to: "/")
+      end
+    else
+      conn
+      |> configure_session(drop: true)
+      |> put_flash(:error, "OIDC callback rejected: invalid state.")
+      |> redirect(to: "/")
+    end
+  end
+
+  def callback(conn, _params) do
+    conn
+    |> put_flash(:error, "OIDC callback rejected: missing code or state.")
+    |> redirect(to: "/")
+  end
+
+  def sign_out(conn, _params) do
+    conn
+    |> configure_session(drop: true)
+    |> redirect(to: "/")
+  end
+
+  defp redirect_uri(conn) do
+    %URI{
+      scheme: Atom.to_string(conn.scheme),
+      host: conn.host,
+      port: conn.port,
+      path: "/auth/callback"
+    }
+    |> URI.to_string()
+  end
+
+  defp random_state do
+    32
+    |> :crypto.strong_rand_bytes()
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp format_reason({kind, status, body}), do: "#{kind} (#{status}): #{inspect(body)}"
+  defp format_reason(reason), do: inspect(reason)
+end

--- a/roundtable/lib/roundtable_web/router.ex
+++ b/roundtable/lib/roundtable_web/router.ex
@@ -9,12 +9,20 @@ defmodule RoundtableWeb.Router do
     plug(:put_root_layout, html: {RoundtableWeb.Layouts, :root})
     plug(:protect_from_forgery)
     plug(:put_secure_browser_headers)
+    plug(RoundtableWeb.UserAuth)
   end
 
   scope "/", RoundtableWeb do
     pipe_through(:browser)
 
-    live("/", DiscussionLive)
+    get("/auth/sign_in", AuthController, :sign_in)
+    get("/auth/callback", AuthController, :callback)
+    get("/auth/sign_out", AuthController, :sign_out)
+
+    live_session :authenticated, on_mount: [{RoundtableWeb.UserAuth, :ensure_authenticated}] do
+      live("/", DiscussionLive)
+    end
+
     live("/forgejo-shell", ForgejoShellLive)
   end
 end

--- a/roundtable/lib/roundtable_web/user_auth.ex
+++ b/roundtable/lib/roundtable_web/user_auth.ex
@@ -1,0 +1,60 @@
+defmodule RoundtableWeb.UserAuth do
+  @moduledoc false
+
+  import Plug.Conn
+  import Phoenix.Controller
+  import Phoenix.LiveView
+
+  alias Roundtable.Auth
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    assign(conn, :current_user, get_session(conn, :current_user))
+  end
+
+  def on_mount(:ensure_authenticated, _params, session, socket) do
+    current_user = session["current_user"]
+    socket = assign(socket, :current_user, current_user)
+
+    cond do
+      not Auth.enabled?() ->
+        {:cont, socket}
+
+      is_map(current_user) ->
+        {:cont, socket}
+
+      true ->
+        {:halt, Phoenix.LiveView.redirect(socket, to: "/auth/sign_in")}
+    end
+  end
+
+  def authorize_repo(_current_user, repo) when repo in [nil, ""], do: :ok
+
+  def authorize_repo(current_user, repo) do
+    github_login = current_user && current_user["github_login"]
+
+    cond do
+      not Auth.enabled?() ->
+        :ok
+
+      github_login in [nil, ""] ->
+        {:error, "GitHub identity is missing from the session."}
+
+      true ->
+        case Auth.repo_readable_by?(repo, github_login) do
+          {:ok, true} ->
+            :ok
+
+          {:ok, false} ->
+            {:error, "GitHub user #{github_login} does not have access to #{repo}."}
+
+          {:error, :missing_service_pat} ->
+            {:error, "The service is missing GITHUB_SERVICE_PAT/GH_TOKEN for repo access checks."}
+
+          {:error, reason} ->
+            {:error, "Repo access check failed: #{inspect(reason)}"}
+        end
+    end
+  end
+end

--- a/roundtable/test/roundtable/auth_test.exs
+++ b/roundtable/test/roundtable/auth_test.exs
@@ -1,0 +1,47 @@
+defmodule Roundtable.AuthTest do
+  use ExUnit.Case, async: true
+
+  alias Roundtable.Auth
+
+  setup do
+    previous = Application.get_env(:roundtable, Roundtable.Auth)
+
+    on_exit(fn ->
+      if previous == nil do
+        Application.delete_env(:roundtable, Roundtable.Auth)
+      else
+        Application.put_env(:roundtable, Roundtable.Auth, previous)
+      end
+
+      System.delete_env("GITHUB_SERVICE_PAT")
+      System.delete_env("GH_TOKEN")
+    end)
+
+    :ok
+  end
+
+  test "repo_readable_by?/2 accepts readable permissions" do
+    Application.put_env(:roundtable, Roundtable.Auth,
+      http_client: fn :get, "https://api.github.com/repos/owner/repo/collaborators/deep/permission", opts ->
+        assert {"authorization", "Bearer ghp_test"} in Keyword.fetch!(opts, :headers)
+        {:ok, %{status: 200, body: %{"permission" => "read"}}}
+      end
+    )
+
+    System.put_env("GITHUB_SERVICE_PAT", "ghp_test")
+
+    assert Auth.repo_readable_by?("owner/repo", "deep") == {:ok, true}
+  end
+
+  test "repo_readable_by?/2 returns false for missing collaborator access" do
+    Application.put_env(:roundtable, Roundtable.Auth,
+      http_client: fn :get, "https://api.github.com/repos/owner/repo/collaborators/deep/permission", _opts ->
+        {:ok, %{status: 404, body: %{}}}
+      end
+    )
+
+    System.put_env("GITHUB_SERVICE_PAT", "ghp_test")
+
+    assert Auth.repo_readable_by?("owner/repo", "deep") == {:ok, false}
+  end
+end

--- a/roundtable/test/roundtable/auth_test.exs
+++ b/roundtable/test/roundtable/auth_test.exs
@@ -13,6 +13,7 @@ defmodule Roundtable.AuthTest do
         Application.put_env(:roundtable, Roundtable.Auth, previous)
       end
 
+      System.delete_env("OIDC_ISSUER_URL")
       System.delete_env("GITHUB_SERVICE_PAT")
       System.delete_env("GH_TOKEN")
     end)
@@ -43,5 +44,30 @@ defmodule Roundtable.AuthTest do
     System.put_env("GITHUB_SERVICE_PAT", "ghp_test")
 
     assert Auth.repo_readable_by?("owner/repo", "deep") == {:ok, false}
+  end
+
+  test "authorization_url/2 returns an error when discovery metadata is incomplete" do
+    Application.put_env(:roundtable, Roundtable.Auth,
+      http_client: fn :get, "https://issuer.example/.well-known/openid-configuration", _opts ->
+        {:ok, %{status: 200, body: %{"token_endpoint" => "https://issuer.example/token"}}}
+      end
+    )
+
+    System.put_env("OIDC_ISSUER_URL", "https://issuer.example")
+
+    assert Auth.authorization_url("state", "https://app.example/auth/callback") ==
+             {:error, :missing_oidc_metadata}
+  end
+
+  test "repo_readable_by?/2 rejects invalid repo slugs before making a request" do
+    System.put_env("GITHUB_SERVICE_PAT", "ghp_test")
+
+    assert Auth.repo_readable_by?("owner/repo?tab=issues", "deep") == {:error, :invalid_repo}
+  end
+
+  test "repo_readable_by?/2 rejects invalid GitHub logins before making a request" do
+    System.put_env("GITHUB_SERVICE_PAT", "ghp_test")
+
+    assert Auth.repo_readable_by?("owner/repo", "deep/user") == {:error, :invalid_github_login}
   end
 end

--- a/roundtable/test/roundtable_web/auth_controller_test.exs
+++ b/roundtable/test/roundtable_web/auth_controller_test.exs
@@ -1,0 +1,58 @@
+defmodule RoundtableWeb.AuthControllerTest do
+  use RoundtableWeb.ConnCase, async: true
+
+  setup_all do
+    case start_supervised(RoundtableWeb.Endpoint) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
+    :ok
+  end
+
+  setup do
+    previous_auth = Application.get_env(:roundtable, Roundtable.Auth)
+
+    on_exit(fn ->
+      if previous_auth == nil do
+        Application.delete_env(:roundtable, Roundtable.Auth)
+      else
+        Application.put_env(:roundtable, Roundtable.Auth, previous_auth)
+      end
+
+      System.delete_env("OIDC_ISSUER_URL")
+    end)
+
+    :ok
+  end
+
+  test "sign_in uses the configured endpoint URL for the callback", %{conn: conn} do
+    Application.put_env(:roundtable, Roundtable.Auth,
+      http_client: fn :get, "https://issuer.example/.well-known/openid-configuration", _opts ->
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "authorization_endpoint" => "https://issuer.example/authorize",
+             "token_endpoint" => "https://issuer.example/token",
+             "userinfo_endpoint" => "https://issuer.example/userinfo"
+           }
+         }}
+      end
+    )
+
+    System.put_env("OIDC_ISSUER_URL", "https://issuer.example")
+
+    conn = get(conn, "/auth/sign_in")
+
+    assert redirected_to(conn, 302) ==
+             "https://issuer.example/authorize?client_id=&redirect_uri=http%3A%2F%2Flocalhost%3A4002%2Fauth%2Fcallback&response_type=code&scope=openid+profile+email&state=" <>
+               get_session(conn, :oidc_state)
+  end
+
+  test "callback route handles missing code or state", %{conn: conn} do
+    conn = get(conn, "/auth/callback")
+
+    assert redirected_to(conn, 302) == "/"
+  end
+end

--- a/roundtable/test/support/conn_case.ex
+++ b/roundtable/test/support/conn_case.ex
@@ -1,0 +1,16 @@
+defmodule RoundtableWeb.ConnCase do
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      use Phoenix.ConnTest
+      import Phoenix.LiveViewTest
+
+      @endpoint RoundtableWeb.Endpoint
+    end
+  end
+
+  setup _tags do
+    {:ok, conn: Phoenix.ConnTest.build_conn()}
+  end
+end

--- a/roundtable/test/test_helper.exs
+++ b/roundtable/test/test_helper.exs
@@ -1,3 +1,4 @@
 ExUnit.start()
 Code.require_file("support/fake_runner.ex", __DIR__)
 Code.require_file("support/stub_backend.ex", __DIR__)
+Code.require_file("support/conn_case.ex", __DIR__)


### PR DESCRIPTION
## Summary
- recover the Authentik OIDC dashboard authentication work from the local feature worktree
- add the OIDC auth helper, controller, session/user auth plumbing, and supporting error view
- include focused auth tests and conn-case support for the web auth path

## Notes
- this branch also carries the original work-item claim commit for item 25

## Testing
- nix develop /home/deepwatrcreatur/flakes/agent-roundtable#default --command env MIX_DEPS_PATH=/home/deepwatrcreatur/flakes/agent-roundtable/roundtable/deps MIX_BUILD_ROOT=/tmp/agent-roundtable-vaglio-oidc-build mix test test/roundtable/auth_test.exs