### PR TITLE
fix(vaglio): harden standalone roundtable service

### DIFF
--- a/docs/work-items/76-standalone-vaglio-service-hardening.md
+++ b/docs/work-items/76-standalone-vaglio-service-hardening.md
@@ -1,0 +1,54 @@
+# 76 — Standalone Vaglio Service Hardening
+
+Status: `in-progress`
+Suggested branch: `fix/standalone-vaglio-service-hardening`
+
+## Goal
+
+Fix the standalone `#vaglio` deployment profile so `roundtable.service` starts
+cleanly on a fresh host without any runtime-only systemd overrides.
+
+## Why
+
+A fresh `nixos-rebuild switch --flake .#vaglio` on the real `vaglio` LXC host
+currently exposes two service bugs:
+
+- the generated startup script assumes `CREDENTIALS_DIRECTORY` always exists
+  under `set -u`
+- the packaged `roundtable-web` wrapper runs Mix from a read-only
+  `/nix/store` source tree, which causes Hex dependency setup to fail with
+  `{:error, :erofs}`
+
+A temporary runtime override on the live host works around this by running from
+`/root/flakes/agent-roundtable/roundtable`, but that fix disappears on reboot
+and does not belong in host-local state.
+
+## Scope
+
+- Make the systemd startup path safe when no credentials are configured.
+- Remove the read-only source-tree assumption from the standalone runtime path.
+- Ensure the default standalone profile can boot the web service from a clean
+  host with only the flake checkout and Nix.
+- Preserve the existing optional-secret behavior for GitHub/OIDC/API-key flows.
+
+## Acceptance Criteria
+
+- `nixos-rebuild switch --flake .#vaglio` succeeds on a clean LXC host.
+- `systemctl status roundtable` is `active (running)` without any runtime-only
+  override in `/run/systemd/system/roundtable.service.d/`.
+- `curl -I http://127.0.0.1:4000` returns `200 OK`.
+- No Hex/Mix writes target `/nix/store` during service startup.
+
+## Notes
+
+Observed on the real `vaglio` host on May 10, 2026:
+
+- `roundtable.service` initially failed with:
+  - `CREDENTIALS_DIRECTORY: unbound variable`
+  - `{:error, :erofs}` during Hex dependency unpack
+- A host-local override proved the app can run when:
+  - the credential directory is treated as optional
+  - the service launches from a writable checkout instead of the packaged
+    read-only source path
+
+Current owner: `fix/standalone-vaglio-service-hardening`

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -125,4 +125,4 @@ Do not work on an item already marked `in-progress` by another agent.
 
 63. [`71-forgejo-shell-shareable-web-entry.md`](./71-forgejo-shell-shareable-web-entry.md) — `done` — **Codex** — `[product]` Forgejo shell shareable web entry
 64. [`72-forgejo-shell-public-demo-polish.md`](./72-forgejo-shell-public-demo-polish.md) — `done` — **Codex** — `[market]` Forgejo shell public demo polish
-65. [`76-standalone-vaglio-service-hardening.md`](./76-standalone-vaglio-service-hardening.md) — `ready` — `[hosting]` Standalone Vaglio service hardening
+65. [`76-standalone-vaglio-service-hardening.md`](./76-standalone-vaglio-service-hardening.md) — `in-progress` — `[hosting]` Standalone Vaglio service hardening

--- a/flake.nix
+++ b/flake.nix
@@ -44,8 +44,19 @@
                 mix_home="$state_home/mix"
                 deps_path="$state_home/deps"
                 build_root="$state_home/build"
+                runtime_src="$state_home/src"
+                source_rev='${self.rev or self.dirtyRev or "dirty"}'
+                source_marker="$runtime_src/.roundtable-source-rev"
 
                 mkdir -p "$state_home" "$mix_home" "$deps_path" "$build_root"
+
+                if [ ! -d "$runtime_src" ] || [ ! -f "$source_marker" ] || [ "$(cat "$source_marker")" != "$source_rev" ]; then
+                  rm -rf "$runtime_src"
+                  mkdir -p "$runtime_src"
+                  cp -R ${roundtableSrc}/. "$runtime_src"/
+                  chmod -R u+w "$runtime_src"
+                  printf '%s\n' "$source_rev" > "$source_marker"
+                fi
 
                 export MIX_ENV="''${MIX_ENV:-prod}"
                 export MIX_HOME="$mix_home"
@@ -54,7 +65,7 @@
                 export MIX_DEPS_PATH="$deps_path"
                 export MIX_BUILD_ROOT="$build_root"
 
-                cd ${roundtableSrc}
+                cd "$runtime_src"
 
                 mix local.hex --force >/dev/null 2>&1 || true
                 mix local.rebar --force >/dev/null 2>&1 || true

--- a/nix/modules/services/roundtable.nix
+++ b/nix/modules/services/roundtable.nix
@@ -14,8 +14,8 @@ let
     lib.optional (file != null) "${name}:${toString file}";
 
   exportOptionalCredential = envName: credentialName: ''
-    if [ -f "$CREDENTIALS_DIRECTORY/${credentialName}" ]; then
-      export ${envName}="$(cat "$CREDENTIALS_DIRECTORY/${credentialName}")"
+    if [ -n "$credential_dir" ] && [ -f "$credential_dir/${credentialName}" ]; then
+      export ${envName}="$(cat "$credential_dir/${credentialName}")"
     fi
   '';
 in
@@ -187,9 +187,10 @@ in
           set -eu
 
           mkdir -p "$HOME/state"
+          credential_dir="''${CREDENTIALS_DIRECTORY:-}"
 
-          if [ -f "$CREDENTIALS_DIRECTORY/secret_key_base" ]; then
-            export SECRET_KEY_BASE="$(cat "$CREDENTIALS_DIRECTORY/secret_key_base")"
+          if [ -n "$credential_dir" ] && [ -f "$credential_dir/secret_key_base" ]; then
+            export SECRET_KEY_BASE="$(cat "$credential_dir/secret_key_base")"
           elif [ -f "$HOME/secret_key_base" ]; then
             export SECRET_KEY_BASE="$(cat "$HOME/secret_key_base")"
           else


### PR DESCRIPTION
Summary:
- make the standalone roundtable systemd start path safe when CREDENTIALS_DIRECTORY is unset
- stage the app source into writable XDG state before running Mix so startup no longer depends on a read-only /nix/store source tree
- add and claim work item 76 in the upstream queue

Validation:
- nix build .#roundtable-web succeeds
- nix build --print-out-paths .#nixosConfigurations.vaglio.config.systemd.services.roundtable.serviceConfig.ExecStart succeeds
- nix eval .#nixosConfigurations.vaglio.config.services.roundtable.enable returned true
- the generated roundtable-web wrapper now copies source into writable state before mix deps.get
- the generated roundtable-start script now guards CREDENTIALS_DIRECTORY with a default-empty credential_dir variable

Operational note:
I did not run a live switch on the real Vaglio host from this branch, so final host-level confirmation still needs a rebuild on the actual LXC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added work item documentation detailing Vaglio standalone service hardening, including scope, acceptance criteria, and implementation notes.

* **Bug Fixes**
  * Fixed service startup failures caused by missing credentials directory environment handling.
  * Fixed Mix/Hex setup failures by enabling mutable runtime access to source files instead of read-only store location.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/agent-roundtable/pull/85)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->