### PR TITLE
fix(vaglio): align phoenix host and prod endpoint config

### DIFF
--- a/nix/modules/profiles/vaglio-base.nix
+++ b/nix/modules/profiles/vaglio-base.nix
@@ -40,7 +40,7 @@
   services.roundtable = {
     enable = true;
     enableTuiTooling = true;
-    phoenixHost = "localhost";
+    phoenixHost = "roundtable.deepwatercreature.com";
   };
 
   system.stateVersion = lib.mkDefault "25.11";

--- a/roundtable/config/prod.exs
+++ b/roundtable/config/prod.exs
@@ -4,8 +4,7 @@ host = System.get_env("HOST") || System.get_env("PHX_HOST") || "localhost"
 
 config :roundtable, RoundtableWeb.Endpoint,
   server: true,
-  url: [host: host],
-  cache_static_manifest: "priv/static/cache_manifest.json"
+  url: [host: host]
 
 config :roundtable,
   web_enabled: System.get_env("ROUNDTABLE_WEB") != "false",


### PR DESCRIPTION
Summary:
- set the Vaglio standalone Roundtable profile to advertise roundtable.deepwatercreature.com instead of localhost
- remove the stale Phoenix cache_static_manifest setting from prod config
- align upstream with the currently working live Vaglio host runtime

Validation:
- nix eval .#nixosConfigurations.vaglio.config.services.roundtable.phoenixHost
- nix build .#roundtable-web
- verified on the live Vaglio host that /forgejo-shell returns HTTP 200 with these runtime semantics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated host configuration endpoint for service deployment.
  * Adjusted production static content cache configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/agent-roundtable/pull/87)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->