### PR TITLE
feat: add shareable public repo reports

### DIFF
--- a/roundtable/lib/roundtable/public_repo_demo.ex
+++ b/roundtable/lib/roundtable/public_repo_demo.ex
@@ -12,6 +12,13 @@ defmodule Roundtable.PublicRepoDemo do
   alias Roundtable.{InvestorDemo, SystemCmdRunner}
 
   @type options :: keyword()
+  @type report_entry :: %{
+          demo: map(),
+          source: map() | nil,
+          imported_repo: map() | nil,
+          cache_status: :cached | :fallback,
+          generated_at: String.t() | nil
+        }
 
   @spec snapshot(String.t(), options()) :: {:ok, map()} | {:error, term()}
   def snapshot(id, opts \\ []) do
@@ -83,6 +90,12 @@ defmodule Roundtable.PublicRepoDemo do
           end
       end
     end
+  end
+
+  @spec report_entries(options()) :: [report_entry()]
+  def report_entries(opts \\ []) do
+    InvestorDemo.catalog()
+    |> Enum.map(&build_report_entry(&1, opts))
   end
 
   @spec export_snapshot(String.t(), options()) :: {:ok, Path.t()} | {:error, term()}
@@ -163,6 +176,39 @@ defmodule Roundtable.PublicRepoDemo do
 
       {:error, _reason} = error ->
         error
+    end
+  end
+
+  defp build_report_entry(demo_summary, opts) do
+    base_url = Keyword.get(opts, :base_url, "https://codeberg.org")
+    cache_root = Keyword.get(opts, :cache_root, default_cache_root())
+
+    with {:ok, demo} <- InvestorDemo.import(demo_summary.id, base_url: base_url),
+         snapshot when snapshot != :miss <- read_cached_report_snapshot(cache_root, demo_summary.id) do
+      %{
+        demo: demo,
+        source: snapshot.source,
+        imported_repo: snapshot.imported_repo,
+        cache_status: :cached,
+        generated_at: snapshot.generated_at
+      }
+    else
+      _ ->
+        %{
+          demo: demo_summary,
+          source: nil,
+          imported_repo: nil,
+          cache_status: :fallback,
+          generated_at: nil
+        }
+    end
+  end
+
+  defp read_cached_report_snapshot(cache_root, id) do
+    case read_cached_snapshot(cache_path(cache_root, id), 365 * 24 * 60 * 60 * 1_000) do
+      {:ok, snapshot} -> snapshot
+      {:stale, snapshot} -> snapshot
+      :miss -> :miss
     end
   end
 

--- a/roundtable/lib/roundtable_web/live/forgejo_shell_live.ex
+++ b/roundtable/lib/roundtable_web/live/forgejo_shell_live.ex
@@ -94,6 +94,7 @@ defmodule RoundtableWeb.ForgejoShellLive do
             <a href={"#demo-#{@selected_demo}"} style={cta_style(:primary)}>Start with this demo</a>
             <a :if={@demo} href={@demo.source.url} style={cta_style(:secondary)}>Open public source</a>
             <a :if={@demo} href={@demo.imported_repo.repo_url} style={cta_style(:secondary)}>Open imported Forgejo target</a>
+            <a href="/forgejo-shell/reports" style={cta_style(:secondary)}>Open snapshot reports</a>
           </div>
         </div>
 

--- a/roundtable/lib/roundtable_web/live/forgejo_shell_reports_live.ex
+++ b/roundtable/lib/roundtable_web/live/forgejo_shell_reports_live.ex
@@ -1,0 +1,245 @@
+defmodule RoundtableWeb.ForgejoShellReportsLive do
+  @moduledoc """
+  Shareable reports surface for cached public repo demo snapshots.
+  """
+
+  use Phoenix.LiveView
+
+  alias Roundtable.PublicRepoDemo
+
+  @impl true
+  def mount(_params, _session, socket) do
+    reports = PublicRepoDemo.report_entries(report_opts())
+    {:ok, assign(socket, :reports, reports)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div style="max-width: 1180px; margin: 0 auto; padding: 2rem 1rem 4rem;">
+      <header style="display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1.25rem; align-items: start; margin-bottom: 2rem;">
+        <div>
+          <div style="display: inline-flex; align-items: center; gap: 0.45rem; border: 1px solid #30363d; border-radius: 999px; padding: 0.35rem 0.75rem; color: #58a6ff; font-size: 0.76rem; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.85rem;">
+            Shareable report surface
+          </div>
+          <h1 style="font-size: clamp(2rem, 5vw, 3rem); line-height: 1.02; color: #f0f6fc; margin-bottom: 0.6rem;">
+            Public Repo Snapshot Reports
+          </h1>
+          <p style="color: #8b949e; max-width: 760px; line-height: 1.6; margin-bottom: 1rem;">
+            These reports are built from the cached public repo snapshots that power the Forgejo shell demo. They are easier to share than the interactive shell and make the computed evidence visible at a glance.
+          </p>
+          <div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
+            <a href="/forgejo-shell" style={cta_style(:primary)}>Back to live demo</a>
+            <a href="#report-forgejo" style={cta_style(:secondary)}>Jump to first report</a>
+          </div>
+        </div>
+
+        <div style="background: linear-gradient(180deg, rgba(22,27,34,0.96), rgba(13,17,23,0.96)); border: 1px solid #30363d; border-radius: 16px; padding: 1.1rem;">
+          <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.6rem;">
+            What this proves
+          </div>
+          <ul style="margin: 0; padding-left: 1rem; color: #8b949e; line-height: 1.65;">
+            <li>Each report is tied to a named public source and imported Forgejo target.</li>
+            <li>Contributor, commit, and hotspot tables come from cached sampled history when available.</li>
+            <li>Cached report state makes the page easier to share than the interactive shell alone.</li>
+          </ul>
+        </div>
+      </header>
+
+      <section style="margin-bottom: 2rem;">
+        <h2 style={section_heading_style()}>Available Reports</h2>
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 0.75rem;">
+          <a
+            :for={report <- @reports}
+            href={"#report-#{report.demo.id}"}
+            style="display: block; text-decoration: none; background: #161b22; border: 1px solid #30363d; border-radius: 10px; padding: 1rem;"
+          >
+            <div style="display: flex; justify-content: space-between; gap: 0.75rem; align-items: baseline; margin-bottom: 0.5rem;">
+              <span style="color: #f0f6fc; font-weight: 600;">{report.demo.name}</span>
+              <span style={"color: #{cache_status_color(report.cache_status)}; font-size: 0.75rem; text-transform: uppercase;"}>{cache_status_label(report.cache_status)}</span>
+            </div>
+            <div style="color: #58a6ff; font-size: 0.8rem;">{report.demo.source_label}</div>
+            <div style="color: #8b949e; font-size: 0.82rem; margin-top: 0.5rem; line-height: 1.45;">{report.demo.teaser}</div>
+          </a>
+        </div>
+      </section>
+
+      <section :for={report <- @reports} id={"report-#{report.demo.id}"} style="margin-bottom: 2rem;">
+        <div style="display: flex; justify-content: space-between; gap: 1rem; align-items: baseline; margin-bottom: 0.85rem; flex-wrap: wrap;">
+          <div>
+            <h2 style="margin: 0; color: #f0f6fc; font-size: 1.25rem;">{report.demo.name}</h2>
+            <div style="color: #58a6ff; font-size: 0.82rem; margin-top: 0.35rem;">{report.demo.source_label}</div>
+          </div>
+          <div style="color: #8b949e; font-size: 0.82rem;">
+            <span style={"color: #{cache_status_color(report.cache_status)}; text-transform: uppercase; margin-right: 0.6rem;"}>{cache_status_label(report.cache_status)}</span>
+            <span :if={report.generated_at}>Generated {format_generated_at(report.generated_at)}</span>
+          </div>
+        </div>
+
+        <div style="background: #161b22; border: 1px solid #30363d; border-radius: 10px; padding: 1rem; margin-bottom: 0.75rem;">
+          <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 0.75rem;">
+            <div>
+              <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase;">Public source</div>
+              <a :if={report.source} href={report.source.url} style="color: #f0f6fc; text-decoration: none; font-weight: 600;">{report.source.slug}</a>
+              <span :if={!report.source} style="color: #8b949e;">Cached source metadata unavailable</span>
+            </div>
+            <div>
+              <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase;">Imported Forgejo target</div>
+              <a :if={report.imported_repo} href={report.imported_repo.repo_url} style="color: #f0f6fc; text-decoration: none; font-weight: 600;">{report.imported_repo.slug}</a>
+              <span :if={!report.imported_repo} style="color: #8b949e;">Imported target unavailable</span>
+            </div>
+          </div>
+        </div>
+
+        <div :if={report.source && report.source.history_summary} style="display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.75rem; margin-bottom: 0.75rem;">
+          <.metric_card metric={metric("Sampled commits", to_string(report.source.history_summary.sampled_commit_count), "Shallow history sample cached from the tracked branch.")} />
+          <.metric_card metric={metric("Contributor count", to_string(report.source.history_summary.contributor_count), "Unique contributors observed in the cached sample.")} />
+          <.metric_card metric={metric("Top author share", derived_percentage(report.source.history_summary.derived_signals.top_author_share), "Share of sampled commits attributable to the top three contributors.")} accent={:heat} />
+          <.metric_card metric={metric("Commit cadence", "#{report.source.history_summary.derived_signals.commits_per_day_window}/day", "Recent sampled commits per day across the cached window.")} />
+        </div>
+
+        <div :if={report.source && report.source.history_summary} style="display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 0.75rem;">
+          <.contributors_table contributors={report.source.history_summary.top_contributors} />
+          <.commit_log_table commits={report.source.history_summary.recent_commits} />
+          <.path_hotspots_table hotspots={report.source.history_summary.path_hotspots} />
+        </div>
+
+        <div :if={!report.source} style="background: #161b22; border: 1px solid #59343b; border-radius: 10px; padding: 1rem; color: #c9d1d9; line-height: 1.55;">
+          Cached sampled evidence was unavailable when this page loaded, so this report is currently limited to the curated demo shell. Re-open the interactive demo to refresh the cache path before sharing this report.
+        </div>
+      </section>
+    </div>
+    """
+  end
+
+  defp metric(label, value, note), do: %{label: label, value: value, note: note}
+
+  defp cache_status_label(:cached), do: "cached"
+  defp cache_status_label(:fallback), do: "fallback"
+
+  defp cache_status_color(:cached), do: "#3fb950"
+  defp cache_status_color(:fallback), do: "#d29922"
+
+  defp format_generated_at(value) do
+    with {:ok, datetime, _offset} <- DateTime.from_iso8601(value) do
+      Calendar.strftime(datetime, "%Y-%m-%d %H:%M UTC")
+    else
+      _ -> value
+    end
+  end
+
+  defp metric_card(assigns) do
+    assigns = assign_new(assigns, :accent, fn -> :default end)
+
+    ~H"""
+    <div style={"background: #161b22; border: 1px solid #{metric_border(@accent)}; border-radius: 8px; padding: 1rem;"}>
+      <div style={"color: #{metric_accent(@accent)}; font-size: 0.78rem; text-transform: uppercase;"}>{@metric.label}</div>
+      <div style="color: #f0f6fc; font-size: 1.4rem; font-weight: 700; margin-top: 0.45rem;">{@metric.value}</div>
+      <p style="margin: 0.6rem 0 0; color: #8b949e; line-height: 1.45;">{@metric.note}</p>
+    </div>
+    """
+  end
+
+  defp contributors_table(assigns) do
+    ~H"""
+    <div style="background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 1rem;">
+      <h3 style="margin: 0 0 0.75rem; color: #f0f6fc; font-size: 0.95rem;">Top sampled contributors</h3>
+      <table style="width: 100%; border-collapse: collapse; font-size: 0.84rem;">
+        <thead>
+          <tr style="text-align: left; color: #58a6ff; border-bottom: 1px solid #30363d;">
+            <th style="padding: 0.45rem 0;">Author</th>
+            <th style="padding: 0.45rem 0;">Email</th>
+            <th style="padding: 0.45rem 0; text-align: right;">Commits</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr :for={contributor <- @contributors} style="border-bottom: 1px solid #21262d;">
+            <td style="padding: 0.5rem 0; color: #f0f6fc;">{contributor.author}</td>
+            <td style="padding: 0.5rem 0; color: #8b949e;">{contributor.email}</td>
+            <td style="padding: 0.5rem 0; color: #f0f6fc; text-align: right;">{contributor.commits}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  defp commit_log_table(assigns) do
+    ~H"""
+    <div style="background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 1rem;">
+      <h3 style="margin: 0 0 0.75rem; color: #f0f6fc; font-size: 0.95rem;">Recent sampled commits</h3>
+      <table style="width: 100%; border-collapse: collapse; font-size: 0.84rem;">
+        <thead>
+          <tr style="text-align: left; color: #58a6ff; border-bottom: 1px solid #30363d;">
+            <th style="padding: 0.45rem 0;">When</th>
+            <th style="padding: 0.45rem 0;">Author</th>
+            <th style="padding: 0.45rem 0;">SHA</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr :for={commit <- @commits} style="border-bottom: 1px solid #21262d;">
+            <td style="padding: 0.5rem 0; color: #8b949e;">{format_commit_day(commit.committed_at_unix)}</td>
+            <td style="padding: 0.5rem 0; color: #f0f6fc;">{commit.author}</td>
+            <td style="padding: 0.5rem 0; color: #8b949e;"><code>{short_sha(commit.sha)}</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  defp path_hotspots_table(assigns) do
+    ~H"""
+    <div style="background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 1rem;">
+      <h3 style="margin: 0 0 0.75rem; color: #f0f6fc; font-size: 0.95rem;">Sampled path hotspots</h3>
+      <table style="width: 100%; border-collapse: collapse; font-size: 0.84rem;">
+        <thead>
+          <tr style="text-align: left; color: #58a6ff; border-bottom: 1px solid #30363d;">
+            <th style="padding: 0.45rem 0;">Path</th>
+            <th style="padding: 0.45rem 0; text-align: right;">Mentions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr :for={hotspot <- @hotspots} style="border-bottom: 1px solid #21262d;">
+            <td style="padding: 0.5rem 0; color: #f0f6fc;"><code>{hotspot.path}</code></td>
+            <td style="padding: 0.5rem 0; color: #f0f6fc; text-align: right;">{hotspot.mentions}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  defp derived_percentage(value) when is_float(value), do: "#{Float.round(value * 100, 0)}%"
+  defp derived_percentage(value), do: to_string(value)
+
+  defp format_commit_day(unix) when is_integer(unix) do
+    unix
+    |> DateTime.from_unix!()
+    |> Calendar.strftime("%Y-%m-%d")
+  end
+
+  defp short_sha(sha) when is_binary(sha), do: String.slice(sha, 0, 8)
+
+  defp metric_accent(:heat), do: "#ff7b72"
+  defp metric_accent(_), do: "#58a6ff"
+
+  defp metric_border(:heat), do: "#59343b"
+  defp metric_border(_), do: "#30363d"
+
+  defp section_heading_style do
+    "font-size: 1rem; color: #8b949e; margin-bottom: 1rem; text-transform: uppercase; letter-spacing: 0.05em;"
+  end
+
+  defp cta_style(:primary) do
+    "display: inline-flex; align-items: center; justify-content: center; text-decoration: none; background: #238636; color: #f0f6fc; border-radius: 999px; padding: 0.72rem 1rem; font-weight: 600; border: 1px solid #2ea043;"
+  end
+
+  defp cta_style(:secondary) do
+    "display: inline-flex; align-items: center; justify-content: center; text-decoration: none; background: transparent; color: #c9d1d9; border-radius: 999px; padding: 0.72rem 1rem; font-weight: 600; border: 1px solid #30363d;"
+  end
+
+  defp report_opts do
+    Keyword.merge([timeout_ms: 2_000, ttl_ms: 15 * 60_000], Application.get_env(:roundtable, __MODULE__, []))
+  end
+end

--- a/roundtable/lib/roundtable_web/router.ex
+++ b/roundtable/lib/roundtable_web/router.ex
@@ -26,5 +26,6 @@ defmodule RoundtableWeb.Router do
     end
 
     live("/forgejo-shell", ForgejoShellLive)
+    live("/forgejo-shell/reports", ForgejoShellReportsLive)
   end
 end

--- a/roundtable/test/roundtable/public_repo_demo_report_entries_test.exs
+++ b/roundtable/test/roundtable/public_repo_demo_report_entries_test.exs
@@ -1,0 +1,70 @@
+defmodule Roundtable.PublicRepoDemoReportEntriesTest do
+  use ExUnit.Case, async: true
+
+  alias Roundtable.PublicRepoDemo
+
+  defmodule FakeCommandRunner do
+    @behaviour Roundtable.CommandRunner
+    @handler_key {__MODULE__, :handler}
+
+    @impl true
+    def cmd(command, args, opts) do
+      handler = :persistent_term.get(@handler_key, nil) || raise "missing fake command handler"
+      handler.(command, args, opts)
+    end
+  end
+
+  setup do
+    :persistent_term.put({FakeCommandRunner, :handler}, fn
+      "git", ["ls-remote", _clone_url, "HEAD", tracked_ref], _opts ->
+        {"123abc\tHEAD\n456def\t#{tracked_ref}\n", 0}
+
+      "git", ["init", _repo_dir], _opts ->
+        {"Initialized empty Git repository\n", 0}
+
+      "git", ["-C", _repo_dir, "remote", "add", "origin", _clone_url], _opts ->
+        {"", 0}
+
+      "git", ["-C", _repo_dir, "fetch", "--depth", _depth, "origin", _tracked_ref], _opts ->
+        {"", 0}
+
+      "git", ["-C", _repo_dir, "rev-list", "--count", "FETCH_HEAD"], _opts ->
+        {"40\n", 0}
+
+      "git", ["-C", _repo_dir, "shortlog", "-sne", "FETCH_HEAD"], _opts ->
+        {"   22  Alice Example <alice@example.com>\n   11  Bob Example <bob@example.com>\n    7  Carol Example <carol@example.com>\n", 0}
+
+      "git", ["-C", _repo_dir, "log", "--format=%ct\t%an\t%H", "--max-count=" <> _limit, "FETCH_HEAD"], _opts ->
+        {"1715616000\tAlice Example\tdeadbeef\n1715529600\tBob Example\tcafebabe\n", 0}
+
+      "git", ["-C", _repo_dir, "log", "--format=", "--name-only", "--max-count=" <> _limit, "FETCH_HEAD"], _opts ->
+        {"pkg/a\npkg/a\npkg/b\n", 0}
+    end)
+
+    :ok
+  end
+
+  test "builds report entries from cached snapshots" do
+    cache_root = Path.join(System.tmp_dir!(), "roundtable-public-reports-#{System.unique_integer()}")
+
+    assert {:ok, _snapshot} =
+             PublicRepoDemo.cached_snapshot("forgejo",
+        runner: FakeCommandRunner,
+        cache_root: cache_root,
+        ttl_ms: 60_000,
+        timeout_ms: 100
+      )
+
+    entries =
+      PublicRepoDemo.report_entries(
+        runner: FakeCommandRunner,
+        cache_root: cache_root
+      )
+
+    forgejo = Enum.find(entries, &(&1.demo.id == "forgejo"))
+
+    assert forgejo.cache_status == :cached
+    assert forgejo.source.slug == "forgejo/forgejo"
+    assert forgejo.source.history_summary.sampled_commit_count == 40
+  end
+end

--- a/roundtable/test/roundtable_web/forgejo_shell_live_test.exs
+++ b/roundtable/test/roundtable_web/forgejo_shell_live_test.exs
@@ -26,6 +26,7 @@ defmodule RoundtableWeb.ForgejoShellLiveTest do
     assert html =~ "Forgejo Code Server Shell"
     assert html =~ "Public demo shell"
     assert html =~ "Start with this demo"
+    assert html =~ "Open snapshot reports"
     assert html =~ "Recommended first view"
     assert html =~ "Recommended first click"
     assert html =~ "Curated Investor Demos"

--- a/roundtable/test/roundtable_web/forgejo_shell_reports_live_test.exs
+++ b/roundtable/test/roundtable_web/forgejo_shell_reports_live_test.exs
@@ -1,0 +1,38 @@
+defmodule RoundtableWeb.ForgejoShellReportsLiveTest do
+  use ExUnit.Case, async: false
+  import Phoenix.ConnTest
+
+  @endpoint RoundtableWeb.Endpoint
+
+  setup_all do
+    case start_supervised(RoundtableWeb.Endpoint) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
+    :ok
+  end
+
+  setup do
+    previous = Application.get_env(:roundtable, RoundtableWeb.ForgejoShellReportsLive, [])
+    Application.put_env(:roundtable, RoundtableWeb.ForgejoShellReportsLive, timeout_ms: 1, ttl_ms: 1)
+
+    on_exit(fn ->
+      Application.put_env(:roundtable, RoundtableWeb.ForgejoShellReportsLive, previous)
+    end)
+
+    :ok
+  end
+
+  test "renders the reports page" do
+    conn = get(build_conn(), "/forgejo-shell/reports")
+    html = html_response(conn, 200)
+
+    assert html =~ "Public Repo Snapshot Reports"
+    assert html =~ "Available Reports"
+    assert html =~ "forgejo/forgejo"
+    assert html =~ "kubernetes/kubernetes"
+    assert html =~ "NixOS/nixpkgs"
+    assert html =~ "Back to live demo"
+  end
+end


### PR DESCRIPTION
## Summary
- add a shareable /forgejo-shell/reports LiveView backed by cached public repo snapshots
- add PublicRepoDemo.report_entries/1 to expose cached report data without re-sampling on page load
- link the live demo to the reports page and cover the new surface with focused tests

## Testing
- nix develop . --command bash -lc 'cd roundtable && mix test test/roundtable/public_repo_demo_test.exs test/roundtable/public_repo_demo_report_entries_test.exs test/roundtable_web/forgejo_shell_live_test.exs test/roundtable_web/forgejo_shell_reports_live_test.exs'
