### PR TITLE
fix: preserve report demo summary fields

### DIFF
--- a/roundtable/lib/roundtable/public_repo_demo.ex
+++ b/roundtable/lib/roundtable/public_repo_demo.ex
@@ -186,7 +186,7 @@ defmodule Roundtable.PublicRepoDemo do
     with {:ok, demo} <- InvestorDemo.import(demo_summary.id, base_url: base_url),
          snapshot when snapshot != :miss <- read_cached_report_snapshot(cache_root, demo_summary.id) do
       %{
-        demo: demo,
+        demo: Map.merge(demo_summary, demo),
         source: snapshot.source,
         imported_repo: snapshot.imported_repo,
         cache_status: :cached,

--- a/roundtable/test/roundtable/public_repo_demo_report_entries_test.exs
+++ b/roundtable/test/roundtable/public_repo_demo_report_entries_test.exs
@@ -64,6 +64,7 @@ defmodule Roundtable.PublicRepoDemoReportEntriesTest do
     forgejo = Enum.find(entries, &(&1.demo.id == "forgejo"))
 
     assert forgejo.cache_status == :cached
+    assert forgejo.demo.source_label == "Codeberg source"
     assert forgejo.source.slug == "forgejo/forgejo"
     assert forgejo.source.history_summary.sampled_commit_count == 40
   end


### PR DESCRIPTION
## Summary
- preserve summary-only report fields like source_label when building cached report entries
- cover the cached report-entry shape with a regression assertion
- fix the live /forgejo-shell/reports route that was returning 500 on vaglio after the reports feature deploy

## Testing
- nix develop . --command bash -lc 'cd roundtable && mix test test/roundtable/public_repo_demo_test.exs test/roundtable/public_repo_demo_report_entries_test.exs test/roundtable_web/forgejo_shell_live_test.exs test/roundtable_web/forgejo_shell_reports_live_test.exs'

## Deploy note
- deployed live to vaglio while preparing this PR
