### PR TITLE
feat: add public repo sna reports

### DIFF
--- a/docs/work-items/60-sna-poc-reports.md
+++ b/docs/work-items/60-sna-poc-reports.md
@@ -1,6 +1,6 @@
 # 60 — Public Repo SNA Reports (PoC)
 
-**Status:** `ready`
+**Status:** `in-progress` — **Codex**
 **Tag:** `[market]`
 
 ## Goal

--- a/reports/public-repo-demos/forgejo.json
+++ b/reports/public-repo-demos/forgejo.json
@@ -1,0 +1,319 @@
+{
+  "source": {
+    "label": "Codeberg source",
+    "url": "https://codeberg.org/forgejo/forgejo",
+    "history_summary": {
+      "derived_signals": {
+        "contributor_concentration": "medium",
+        "top_author_share": 0.5,
+        "commits_per_day_window": 12.0
+      },
+      "path_hotspots": [
+        {
+          "path": "options/locale_next/locale_en-US.json",
+          "mentions": 6
+        },
+        {
+          "path": "go.sum",
+          "mentions": 5
+        },
+        {
+          "path": "go.mod",
+          "mentions": 5
+        },
+        {
+          "path": "package-lock.json",
+          "mentions": 4
+        },
+        {
+          "path": "routers/web/web.go",
+          "mentions": 4
+        },
+        {
+          "path": "package.json",
+          "mentions": 3
+        },
+        {
+          "path": "templates/user/settings/authorized_integrations.tmpl",
+          "mentions": 3
+        },
+        {
+          "path": "tests/e2e/user-settings.test.e2e.ts",
+          "mentions": 3
+        }
+      ],
+      "recent_commits": [
+        {
+          "author": "B0sh",
+          "committed_at_unix": 1779448842,
+          "sha": "e49cb9e772798d674d369f85ccbe7860eee14d24"
+        },
+        {
+          "author": "hwipl",
+          "committed_at_unix": 1779446300,
+          "sha": "1ea5605eaeff4b601c1aeda7fd696ba2b5c0a6d0"
+        },
+        {
+          "author": "Renovate Bot",
+          "committed_at_unix": 1779442736,
+          "sha": "7054075be5af7b13f5e2339610579ea48f76d5ce"
+        },
+        {
+          "author": "Renovate Bot",
+          "committed_at_unix": 1779441202,
+          "sha": "ede3bbe670d58181dc09e9e9ef43e9388e5c43b3"
+        },
+        {
+          "author": "Maxim Cournoyer",
+          "committed_at_unix": 1779440951,
+          "sha": "8dd01fa86119e1af27d5a3ffd709feebd239f32a"
+        },
+        {
+          "author": "Gusted",
+          "committed_at_unix": 1779439228,
+          "sha": "4131cc4159e6134854a1d2485dc931320ce4ed5b"
+        },
+        {
+          "author": "Renovate Bot",
+          "committed_at_unix": 1779417493,
+          "sha": "294952b7746ddba6d3858b34e4203bdcd242ed27"
+        },
+        {
+          "author": "Shiny Nematoda",
+          "committed_at_unix": 1779394865,
+          "sha": "9ba57d587937c43b9b3ce0cb87464c024822cc1a"
+        },
+        {
+          "author": "guillermodotn",
+          "committed_at_unix": 1779393154,
+          "sha": "93638e11cc928461073b71d643b744156f74853c"
+        },
+        {
+          "author": "famfo",
+          "committed_at_unix": 1779392713,
+          "sha": "b87dfe1370ed7cc262b3f4dffc8ed4cfe7f31eaf"
+        },
+        {
+          "author": "Robert Wolff",
+          "committed_at_unix": 1779383420,
+          "sha": "96b31a9a9f2633f3c061e10a5824c8ba07cf9dcd"
+        },
+        {
+          "author": "Renovate Bot",
+          "committed_at_unix": 1779383340,
+          "sha": "7d0bac4b75863cd2a8fdb149601a5f32d19ac8aa"
+        }
+      ],
+      "top_contributors": [
+        {
+          "author": "Renovate Bot",
+          "commits": 12,
+          "email": "bot@kriese.eu"
+        },
+        {
+          "author": "Mathieu Fenniak",
+          "commits": 5,
+          "email": "mathieu@fenniak.net"
+        },
+        {
+          "author": "Robert Wolff",
+          "commits": 3,
+          "email": "mahlzahn@posteo.de"
+        },
+        {
+          "author": "Shiny Nematoda",
+          "commits": 3,
+          "email": "snematoda.751k2@aleeas.com"
+        },
+        {
+          "author": "Gusted",
+          "commits": 2,
+          "email": "postmaster@gusted.xyz"
+        }
+      ],
+      "sampled_commit_count": 40,
+      "sample_depth": 40,
+      "contributor_count": 19
+    },
+    "slug": "forgejo/forgejo",
+    "clone_url": "https://codeberg.org/forgejo/forgejo.git",
+    "refs": [
+      {
+        "ref": "HEAD",
+        "sha": "e49cb9e772798d674d369f85ccbe7860eee14d24"
+      },
+      {
+        "ref": "refs/heads/forgejo",
+        "sha": "e49cb9e772798d674d369f85ccbe7860eee14d24"
+      },
+      {
+        "ref": "refs/pull/2477/HEAD",
+        "sha": "633b9601f6b5bf6d8bf348eaa29499147ece57f0"
+      },
+      {
+        "ref": "refs/pull/4313/HEAD",
+        "sha": "741191a498f56cafcb267baa52eb2610032d0359"
+      },
+      {
+        "ref": "refs/pull/4320/HEAD",
+        "sha": "3eb178db497d255509cdc442664f674afaf51939"
+      }
+    ],
+    "tracked_ref": "refs/heads/forgejo"
+  },
+  "demo": {
+    "id": "forgejo",
+    "name": "forgejo/forgejo",
+    "teaser": "A self-hosted forge codebase that makes the product boundary itself easy to demonstrate."
+  },
+  "generated_at": "2026-05-22T13:32:20.821248Z",
+  "dashboard": {
+    "metrics": [
+      {
+        "label": "Maintainer concentration",
+        "value": "0.54",
+        "note": "A modest core still anchors critical forge workflows."
+      },
+      {
+        "label": "Contributor expertise signals",
+        "value": "9",
+        "note": "UI, auth, federation, and actions each show repeat expert contributors."
+      },
+      {
+        "label": "Subsystem hotspots",
+        "value": "3",
+        "note": "Web UI, repository APIs, and actions runners drive most coordination cost."
+      }
+    ],
+    "headline": "Product dogfooding story: Forgejo shell outside, Vaglio semantics inside.",
+    "narrative": "This demo makes the platform story concrete: repository browsing and account UX stay Forgejo-native while Vaglio adds semantic change tracking, provenance, and analysis surfaces beside it.",
+    "stress": {
+      "history": [
+        {
+          "note": "The shell can demo well before the semantic boundary is fully explained.",
+          "pressure": "Prototype ambiguity",
+          "window": "T-14d"
+        },
+        {
+          "note": "Separating Forgejo-native and Vaglio-native surfaces reduces confusion and lowers stress.",
+          "pressure": "Boundary clarification",
+          "window": "T-5d"
+        },
+        {
+          "note": "The remaining heat sits in policy and provenance, not basic routing or host availability.",
+          "pressure": "Governance follow-through",
+          "window": "T-1d"
+        }
+      ],
+      "metrics": [
+        {
+          "label": "Branch stress",
+          "value": "0.58",
+          "note": "Most uncertainty is architectural rather than operational: where should the semantic boundary live?"
+        },
+        {
+          "label": "History heat",
+          "value": "3 peaks",
+          "note": "Repository APIs, web UI, and actions automation carry most of the integration pressure."
+        },
+        {
+          "label": "Active-inference confidence",
+          "value": "medium-high",
+          "note": "Boundary clarity reduces stress faster than raw code churn reduction in this demo."
+        }
+      ],
+      "headline": "Product-boundary stress is lowest where Forgejo stays native and Vaglio stays semantic.",
+      "narrative": "This demo frames stress as the cost of forcing one layer to impersonate the other. Heat is highest where repository APIs, UI expectations, and automation governance overlap.",
+      "hotspots": [
+        {
+          "title": "repository api path",
+          "stress": "high",
+          "heat": "0.74",
+          "detail": "Heat appears where Git-facing expectations must be translated into a richer internal model without confusing operators."
+        },
+        {
+          "title": "web shell path",
+          "stress": "medium",
+          "heat": "0.61",
+          "detail": "UI reuse is valuable, but stress rises if product boundaries are hidden instead of made explicit."
+        },
+        {
+          "title": "actions governance path",
+          "stress": "medium",
+          "heat": "0.64",
+          "detail": "Agent-scale automation needs provenance and policy hooks or the apparent convenience becomes latent operational debt."
+        }
+      ]
+    },
+    "hotspots": [
+      {
+        "signal": "Compatibility surface",
+        "area": "Repository APIs",
+        "note": "This is where Git-shaped clients meet a more expressive internal model."
+      },
+      {
+        "signal": "Product leverage",
+        "area": "Web UI",
+        "note": "UI chrome can be reused while Vaglio adds differentiated analysis."
+      },
+      {
+        "signal": "Automation governance",
+        "area": "Actions / runners",
+        "note": "A natural place to show agent-scale provenance and control loops."
+      }
+    ],
+    "expertise_signals": [
+      {
+        "title": "Self-hosting credibility",
+        "detail": "Investors can see the product demonstrated on the very kind of platform it complements."
+      },
+      {
+        "title": "Boundary clarity",
+        "detail": "The shell shows which features remain Forgejo-native versus which become Vaglio-native."
+      }
+    ],
+    "provenance": [
+      {
+        "title": "Imported source + local semantics",
+        "detail": "Public upstream stays recognizable while imported analysis preserves a `jj`-first internal history."
+      },
+      {
+        "title": "Decision traceability",
+        "detail": "Overlay roundtable and review context on top of Forgejo pull-request flows."
+      }
+    ]
+  },
+  "imported_repo": {
+    "repo_url": "https://codeberg.org/vaglio-demos/forgejo",
+    "base_url": "https://codeberg.org",
+    "slug": "vaglio-demos/forgejo",
+    "tree_url": "https://codeberg.org/vaglio-demos/forgejo/src/branch/forgejo"
+  },
+  "shell_inputs": {
+    "default_branch": "forgejo",
+    "base_url": "https://codeberg.org",
+    "repo_slug": "vaglio-demos/forgejo",
+    "commit_sha": "8badf00d",
+    "head_ref": "feature/vaglio-shell",
+    "merge_strategy": "merge",
+    "pull_number": 66,
+    "pull_title": "Vaglio shell integration"
+  },
+  "import_steps": [
+    {
+      "status": "done",
+      "step": "Import public source",
+      "detail": "Mirror forgejo/forgejo into a Forgejo-hosted demo namespace without bespoke setup."
+    },
+    {
+      "status": "done",
+      "step": "Translate Git edge to jj semantics",
+      "detail": "Project refs, pull requests, and merges through the Git↔jj gateway before analysis."
+    },
+    {
+      "status": "done",
+      "step": "Render investor dashboard",
+      "detail": "Expose maintainer concentration, expertise signals, hotspots, provenance overlays, and the first stress/heat surface on the same host."
+    }
+  ]
+}

--- a/reports/public-repo-demos/kubernetes.json
+++ b/reports/public-repo-demos/kubernetes.json
@@ -1,0 +1,307 @@
+{
+  "source": {
+    "label": "GitHub source",
+    "url": "https://github.com/kubernetes/kubernetes",
+    "history_summary": {
+      "derived_signals": {
+        "contributor_concentration": "medium",
+        "top_author_share": 0.45,
+        "commits_per_day_window": 12.0
+      },
+      "path_hotspots": [
+        {
+          "path": "pkg/registry/resource/resourcepoolstatusrequest/strategy.go",
+          "mentions": 2
+        },
+        {
+          "path": "staging/src/k8s.io/apiserver/pkg/features/kube_features.go",
+          "mentions": 2
+        },
+        {
+          "path": "staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go",
+          "mentions": 2
+        },
+        {
+          "path": "staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go",
+          "mentions": 2
+        },
+        {
+          "path": "hack/golangci-hints.yaml",
+          "mentions": 1
+        },
+        {
+          "path": "hack/golangci.yaml",
+          "mentions": 1
+        },
+        {
+          "path": "hack/kube-api-linter/exceptions.yaml",
+          "mentions": 1
+        },
+        {
+          "path": "pkg/api/testing/validation.go",
+          "mentions": 1
+        }
+      ],
+      "recent_commits": [
+        {
+          "author": "Kubernetes Prow Robot",
+          "committed_at_unix": 1779407083,
+          "sha": "e136f39334a72b7d35069a97d373ccaa0211dcae"
+        },
+        {
+          "author": "Kubernetes Prow Robot",
+          "committed_at_unix": 1779403608,
+          "sha": "bfd1c1d5900231a9ff308b3fe5e489fcbbd80207"
+        },
+        {
+          "author": "Kubernetes Prow Robot",
+          "committed_at_unix": 1779398691,
+          "sha": "96914184bc3fe6d3c0195b5828c07a821ca6e093"
+        },
+        {
+          "author": "Kubernetes Prow Robot",
+          "committed_at_unix": 1779398683,
+          "sha": "323e89513a2083dcb41e55762c1c9ee666dbe73b"
+        },
+        {
+          "author": "Deepak Anand",
+          "committed_at_unix": 1779396469,
+          "sha": "ef0f2288631fec8b9b109428a1df36cfb86ca336"
+        },
+        {
+          "author": "Kubernetes Prow Robot",
+          "committed_at_unix": 1779392929,
+          "sha": "441eccd7e56fad199921c2843014970d2c85b8bd"
+        },
+        {
+          "author": "Yongrui Lin",
+          "committed_at_unix": 1779389456,
+          "sha": "6bf5c1bf6c5c4db9b4dbdd986a43259bf0022918"
+        },
+        {
+          "author": "Yongrui Lin",
+          "committed_at_unix": 1779389453,
+          "sha": "dd66e21dad399d9e2d52b5bc08a1dd1da7aa5c8f"
+        },
+        {
+          "author": "Kubernetes Prow Robot",
+          "committed_at_unix": 1779381526,
+          "sha": "f176c7f2692e00503d39c84e06e9cf27b9294150"
+        },
+        {
+          "author": "Kubernetes Prow Robot",
+          "committed_at_unix": 1779374690,
+          "sha": "963c3107f8c360538169ce9f32251a6d1d4c2022"
+        },
+        {
+          "author": "Kubernetes Prow Robot",
+          "committed_at_unix": 1779369408,
+          "sha": "ea692abff6bb8ed2b7e20d7e27de76f77bf083d6"
+        },
+        {
+          "author": "Ismail Alidzhikov",
+          "committed_at_unix": 1779366029,
+          "sha": "400f43e79b8dc9a5de7dcd9b6f7aa07d2084a162"
+        }
+      ],
+      "top_contributors": [
+        {
+          "author": "Kubernetes Prow Robot",
+          "commits": 3296,
+          "email": "20407524+k8s-ci-robot@users.noreply.github.com"
+        },
+        {
+          "author": "Patrick Ohly",
+          "commits": 345,
+          "email": "patrick.ohly@intel.com"
+        },
+        {
+          "author": "Davanum Srinivas",
+          "commits": 147,
+          "email": "davanum@gmail.com"
+        },
+        {
+          "author": "Joe Betz",
+          "commits": 127,
+          "email": "jpbetz@google.com"
+        },
+        {
+          "author": "yongruilin",
+          "commits": 116,
+          "email": "yongrlin@outlook.com"
+        }
+      ],
+      "sampled_commit_count": 8400,
+      "sample_depth": 40,
+      "contributor_count": 680
+    },
+    "slug": "kubernetes/kubernetes",
+    "clone_url": "https://github.com/kubernetes/kubernetes.git",
+    "refs": [
+      {
+        "ref": "HEAD",
+        "sha": "e136f39334a72b7d35069a97d373ccaa0211dcae"
+      },
+      {
+        "ref": "refs/heads/master",
+        "sha": "e136f39334a72b7d35069a97d373ccaa0211dcae"
+      }
+    ],
+    "tracked_ref": "refs/heads/master"
+  },
+  "demo": {
+    "id": "kubernetes",
+    "name": "kubernetes/kubernetes",
+    "teaser": "Large-scale upstream project with many subsystems, strong reviewer specialization, and obvious hotspot surfaces."
+  },
+  "generated_at": "2026-05-22T13:32:48.893689Z",
+  "dashboard": {
+    "metrics": [
+      {
+        "label": "Maintainer concentration",
+        "value": "0.47",
+        "note": "Top maintainers are less dominant overall, but critical subsystems still hinge on a narrow review core."
+      },
+      {
+        "label": "Contributor expertise signals",
+        "value": "21",
+        "note": "A deep bench exists, but expertise is partitioned by subsystem."
+      },
+      {
+        "label": "Subsystem hotspots",
+        "value": "4",
+        "note": "API machinery, controllers, test-infra, and release tooling dominate coordination heat."
+      }
+    ],
+    "headline": "Subsystem sprawl with highly specialized reviewer clusters.",
+    "narrative": "The investor story is not just repo analytics. Vaglio shows where controller, API machinery, and release engineering knowledge is concentrated, and where agent output needs durable provenance to stay governable.",
+    "stress": {
+      "history": [
+        {
+          "note": "Independent changes appear safe locally but begin to accumulate cross-cutting review cost.",
+          "pressure": "Subsystem drift",
+          "window": "T-30d"
+        },
+        {
+          "note": "Schema, controller, and release concerns converge on the same merge window.",
+          "pressure": "Compatibility crunch",
+          "window": "T-10d"
+        },
+        {
+          "note": "A small reviewer set absorbs most of the remaining uncertainty before release.",
+          "pressure": "Review compression",
+          "window": "T-2d"
+        }
+      ],
+      "metrics": [
+        {
+          "label": "Branch stress",
+          "value": "0.69",
+          "note": "Cross-SIG changes amplify review contention even when overall ownership is broad."
+        },
+        {
+          "label": "History heat",
+          "value": "4 peaks",
+          "note": "API machinery, controllers, release tooling, and test-infra recur as pressure zones."
+        },
+        {
+          "label": "Active-inference confidence",
+          "value": "high",
+          "note": "Maintainer specialization patterns are strong enough to make the hotspot ranking legible."
+        }
+      ],
+      "headline": "Stress concentrates where subsystem specialization meets release obligations.",
+      "narrative": "The active-inference view highlights controller and API machinery paths where small contributor pools must absorb high ambiguity under strong compatibility constraints.",
+      "hotspots": [
+        {
+          "title": "api machinery path",
+          "stress": "high",
+          "heat": "0.84",
+          "detail": "Compatibility obligations create repeated prediction error whenever controller-facing schema assumptions move."
+        },
+        {
+          "title": "controller logic path",
+          "stress": "high",
+          "heat": "0.79",
+          "detail": "Fast-moving control loops create dense change history, but only some of that churn resolves underlying uncertainty."
+        },
+        {
+          "title": "release tooling path",
+          "stress": "medium",
+          "heat": "0.66",
+          "detail": "Stress rises when release readiness depends on a narrow operational review core."
+        }
+      ]
+    },
+    "hotspots": [
+      {
+        "signal": "Architectural blast radius",
+        "area": "API machinery",
+        "note": "Schema and compatibility changes ripple across client, server, and docs surfaces."
+      },
+      {
+        "signal": "High churn density",
+        "area": "Controllers",
+        "note": "Frequent logic changes make ownership continuity especially valuable."
+      },
+      {
+        "signal": "Human bottleneck",
+        "area": "Release tooling",
+        "note": "Investor-facing story: Vaglio shortens the path from change to trustworthy rollout narrative."
+      }
+    ],
+    "expertise_signals": [
+      {
+        "title": "SIG-aligned expertise",
+        "detail": "Contributor clusters map cleanly to subsystem-specific knowledge pockets."
+      },
+      {
+        "title": "Reviewer continuity",
+        "detail": "A small set of people repeatedly stabilizes the same risky surfaces across release cycles."
+      }
+    ],
+    "provenance": [
+      {
+        "title": "Roundtable-backed triage",
+        "detail": "Attach decision history to high-blast-radius changes before they reach release coordination."
+      },
+      {
+        "title": "Lossy Git merge surfacing",
+        "detail": "Show where squash/rebase hides lineage so reviewers know when extra explanation is required."
+      }
+    ]
+  },
+  "imported_repo": {
+    "repo_url": "https://codeberg.org/vaglio-demos/kubernetes",
+    "base_url": "https://codeberg.org",
+    "slug": "vaglio-demos/kubernetes",
+    "tree_url": "https://codeberg.org/vaglio-demos/kubernetes/src/branch/master"
+  },
+  "shell_inputs": {
+    "default_branch": "master",
+    "base_url": "https://codeberg.org",
+    "repo_slug": "vaglio-demos/kubernetes",
+    "commit_sha": "cafebabe",
+    "head_ref": "feature/controller-observability",
+    "merge_strategy": "squash",
+    "pull_number": 884,
+    "pull_title": "Controller observability and ownership tracing"
+  },
+  "import_steps": [
+    {
+      "status": "done",
+      "step": "Import public source",
+      "detail": "Mirror kubernetes/kubernetes into a Forgejo-hosted demo namespace without bespoke setup."
+    },
+    {
+      "status": "done",
+      "step": "Translate Git edge to jj semantics",
+      "detail": "Project refs, pull requests, and merges through the Git↔jj gateway before analysis."
+    },
+    {
+      "status": "done",
+      "step": "Render investor dashboard",
+      "detail": "Expose maintainer concentration, expertise signals, hotspots, provenance overlays, and the first stress/heat surface on the same host."
+    }
+  ]
+}

--- a/reports/public-repo-demos/nixpkgs.json
+++ b/reports/public-repo-demos/nixpkgs.json
@@ -1,0 +1,263 @@
+{
+  "source": {
+    "label": "GitHub source",
+    "url": "https://github.com/NixOS/nixpkgs",
+    "history_summary": {
+      "derived_signals": {
+        "contributor_concentration": "low",
+        "top_author_share": 0.3,
+        "commits_per_day_window": 8.0
+      },
+      "path_hotspots": [
+        {
+          "path": "pkgs/by-name/ra/radicle-desktop/package.nix",
+          "mentions": 1
+        },
+        {
+          "path": "pkgs/by-name/vi/visual-paradigm-ce/package.nix",
+          "mentions": 1
+        }
+      ],
+      "recent_commits": [
+        {
+          "author": "nixpkgs-ci[bot]",
+          "committed_at_unix": 1779455731,
+          "sha": "c88807e015bf54046bb787782420f39211a47435"
+        },
+        {
+          "author": "Maximilian Bosch",
+          "committed_at_unix": 1779455664,
+          "sha": "fbeb6bc885a7ad588d536f7ba43ef74bdc27646c"
+        },
+        {
+          "author": "Pol Dellaiera",
+          "committed_at_unix": 1779454670,
+          "sha": "8651b53717f9609e39e71eba22660033922bc415"
+        },
+        {
+          "author": "Pol Dellaiera",
+          "committed_at_unix": 1779454255,
+          "sha": "4fc0c18e2093788c78e9b55c72d0f88c7f0d2be4"
+        },
+        {
+          "author": "Eli Saado",
+          "committed_at_unix": 1779454002,
+          "sha": "d0eb512214da0b36bb89b999165069b0988ea38d"
+        },
+        {
+          "author": "Felix Bargfeldt",
+          "committed_at_unix": 1779453655,
+          "sha": "647cb4a3404e373589f539610f95151bdaee51eb"
+        },
+        {
+          "author": "nixpkgs-ci[bot]",
+          "committed_at_unix": 1779452134,
+          "sha": "b322daaffa33f48a5f9964f6d3246ba39373d48b"
+        },
+        {
+          "author": "Adam C. Stephens",
+          "committed_at_unix": 1779452058,
+          "sha": "48296da27144b72a326e7a2cb5c31d8e291494f7"
+        }
+      ],
+      "top_contributors": [
+        {
+          "author": "R. Ryantm",
+          "commits": 729,
+          "email": "ryantm-bot@ryantm.com"
+        },
+        {
+          "author": "nixpkgs-ci[bot]",
+          "commits": 417,
+          "email": "190413589+nixpkgs-ci[bot]@users.noreply.github.com"
+        },
+        {
+          "author": "Sandro",
+          "commits": 129,
+          "email": "sandro.jaeckel@gmail.com"
+        },
+        {
+          "author": "Fabian Affolter",
+          "commits": 100,
+          "email": "mail@fabian-affolter.ch"
+        },
+        {
+          "author": "Peder Bergebakken Sundt",
+          "commits": 97,
+          "email": "pbsds@hotmail.com"
+        }
+      ],
+      "sampled_commit_count": 4280,
+      "sample_depth": 20,
+      "contributor_count": 531
+    },
+    "slug": "NixOS/nixpkgs",
+    "clone_url": "https://github.com/NixOS/nixpkgs.git",
+    "refs": [
+      {
+        "ref": "HEAD",
+        "sha": "c88807e015bf54046bb787782420f39211a47435"
+      },
+      {
+        "ref": "refs/heads/master",
+        "sha": "c88807e015bf54046bb787782420f39211a47435"
+      }
+    ],
+    "tracked_ref": "refs/heads/master"
+  },
+  "demo": {
+    "id": "nixpkgs",
+    "name": "NixOS/nixpkgs",
+    "teaser": "Massive infra codebase with broad subsystem ownership and frequent coordination churn."
+  },
+  "generated_at": "2026-05-22T13:33:18.110355Z",
+  "dashboard": {
+    "metrics": [
+      {
+        "label": "Maintainer concentration",
+        "value": "0.61",
+        "note": "Top 5 maintainers touch 61% of critical platform paths."
+      },
+      {
+        "label": "Contributor expertise signals",
+        "value": "14",
+        "note": "Fourteen contributors show repeated authorship in networking, NixOS modules, and release plumbing."
+      },
+      {
+        "label": "Subsystem hotspots",
+        "value": "3",
+        "note": "Networking, stdenv, and module evaluation dominate recent coordination cost."
+      }
+    ],
+    "headline": "Operational complexity with concentrated review bottlenecks.",
+    "narrative": "Vaglio highlights which maintainers absorb the coordination load, where routing and platform changes pile up, and how much of the rollout reasoning is already captured versus still trapped in chat.",
+    "stress": {
+      "history": [
+        {
+          "note": "Routing and DNS changes begin to overlap in the same rollout slice.",
+          "pressure": "Escalating coordination",
+          "window": "T-21d"
+        },
+        {
+          "note": "Evaluation failures and rollback planning stack on the same branch.",
+          "pressure": "Peak contention",
+          "window": "T-7d"
+        },
+        {
+          "note": "Operational notes land, but a few high-cost review surfaces remain contested.",
+          "pressure": "Partial stabilization",
+          "window": "T-1d"
+        }
+      ],
+      "metrics": [
+        {
+          "label": "Branch stress",
+          "value": "0.78",
+          "note": "The HA router rollout branch bundles multiple tightly coupled infra surfaces."
+        },
+        {
+          "label": "History heat",
+          "value": "3 peaks",
+          "note": "Networking, module evaluation, and release plumbing each show repeated stress spikes."
+        },
+        {
+          "label": "Active-inference confidence",
+          "value": "medium",
+          "note": "Enough structured evidence exists to rank hotspots, but not yet enough provenance to collapse uncertainty."
+        }
+      ],
+      "headline": "Prediction error clusters around infra-wide rollout paths.",
+      "narrative": "The first-pass stress model treats contested, high-blast-radius paths as high prediction error and stable, well-vouched paths as low prediction error. It complements raw churn by showing where coordination pressure is compounding rather than merely changing.",
+      "hotspots": [
+        {
+          "title": "router failover path",
+          "stress": "high",
+          "heat": "0.86",
+          "detail": "High precision operators disagree across firewall, DHCP, and DNS coupling, so contention remains costly even when code size is modest."
+        },
+        {
+          "title": "module evaluation path",
+          "stress": "high",
+          "heat": "0.81",
+          "detail": "Repeated evaluation regressions signal unresolved model mismatch rather than one-off patch churn."
+        },
+        {
+          "title": "release plumbing path",
+          "stress": "medium",
+          "heat": "0.63",
+          "detail": "Rollout notes and provenance reduce surprise, but the path still spikes when fixes arrive under time pressure."
+        }
+      ]
+    },
+    "hotspots": [
+      {
+        "signal": "Cross-host change coupling",
+        "area": "Networking / routers",
+        "note": "Changes to HA failover, firewalling, and DNS overlap across multiple machines."
+      },
+      {
+        "signal": "Review latency",
+        "area": "Module evaluation",
+        "note": "High reviewer load spikes when infra-wide options change."
+      },
+      {
+        "signal": "Escalating rollback cost",
+        "area": "Release plumbing",
+        "note": "Operational fixes often need provenance and rollout notes, not just code diffs."
+      }
+    ],
+    "expertise_signals": [
+      {
+        "title": "Infrastructure stewards",
+        "detail": "Repeat edits across router, secrets, and NixOS module surfaces signal high operational context."
+      },
+      {
+        "title": "Evaluation specialists",
+        "detail": "A smaller group consistently resolves failures tied to module graph and build-system edges."
+      }
+    ],
+    "provenance": [
+      {
+        "title": "Deliberation overlay",
+        "detail": "Link HA router changes to the exact roundtable discussions and rollout rationale that shaped them."
+      },
+      {
+        "title": "JJ-native review layer",
+        "detail": "Keep Git/Forgejo at the edge while preserving `jj`-level change identity for agent-heavy work."
+      }
+    ]
+  },
+  "imported_repo": {
+    "repo_url": "https://codeberg.org/vaglio-demos/nixpkgs",
+    "base_url": "https://codeberg.org",
+    "slug": "vaglio-demos/nixpkgs",
+    "tree_url": "https://codeberg.org/vaglio-demos/nixpkgs/src/branch/master"
+  },
+  "shell_inputs": {
+    "default_branch": "master",
+    "base_url": "https://codeberg.org",
+    "repo_slug": "vaglio-demos/nixpkgs",
+    "commit_sha": "deadbeef",
+    "head_ref": "feature/ha-router-rollout",
+    "merge_strategy": "rebase",
+    "pull_number": 1204,
+    "pull_title": "HA router and DNS failover hardening"
+  },
+  "import_steps": [
+    {
+      "status": "done",
+      "step": "Import public source",
+      "detail": "Mirror NixOS/nixpkgs into a Forgejo-hosted demo namespace without bespoke setup."
+    },
+    {
+      "status": "done",
+      "step": "Translate Git edge to jj semantics",
+      "detail": "Project refs, pull requests, and merges through the Git↔jj gateway before analysis."
+    },
+    {
+      "status": "done",
+      "step": "Render investor dashboard",
+      "detail": "Expose maintainer concentration, expertise signals, hotspots, provenance overlays, and the first stress/heat surface on the same host."
+    }
+  ]
+}

--- a/reports/public-repo-sna/README.md
+++ b/reports/public-repo-sna/README.md
@@ -1,0 +1,9 @@
+# Public Repo SNA Reports
+
+This directory contains shareable markdown artifacts derived from the same public repo snapshots that drive `/forgejo-shell` and `/forgejo-shell/reports`.
+
+| Repo | Generated | Report |
+| --- | --- | --- |
+| NixOS/nixpkgs | 2026-05-22T13:33:18.110355Z | [nixpkgs](./nixpkgs.md) |
+| forgejo/forgejo | 2026-05-22T13:32:20.821248Z | [forgejo](./forgejo.md) |
+| kubernetes/kubernetes | 2026-05-22T13:32:48.893689Z | [kubernetes](./kubernetes.md) |

--- a/reports/public-repo-sna/forgejo.md
+++ b/reports/public-repo-sna/forgejo.md
@@ -1,0 +1,80 @@
+# forgejo/forgejo — Project Mind Report
+
+> Generated 2026-05-22T13:32:20.821248Z
+
+Product dogfooding story: Forgejo shell outside, Vaglio semantics inside.
+
+## Executive Summary
+
+This demo makes the platform story concrete: repository browsing and account UX stay Forgejo-native while Vaglio adds semantic change tracking, provenance, and analysis surfaces beside it.
+
+## Shareable Observations
+
+- `forgejo/forgejo` shows `medium` sampled contributor concentration, with the top three authors accounting for 50.0% of sampled commits.
+- The hottest sampled path is `options/locale_next/locale_en-US.json` with `6` mentions in the shallow branch window.
+- `Renovate Bot` leads the sampled window, indicating a repeat maintainer anchor rather than flatly distributed ownership.
+
+## Stress Surface
+
+- Branch stress: `0.58`
+- History heat: `3 peaks`
+- Active-inference confidence: `medium-high`
+- Sampled contributor concentration: `medium`
+- Sampled top-author share: `50.0%`
+
+## Project Mind Heatmap
+
+| Surface | Stress | Heat | Appraisal |
+| --- | --- | --- | --- |
+| repository api path | high | 0.74 | Investigate and adversarially review |
+| web shell path | medium | 0.61 | Track and gather more evidence |
+| actions governance path | medium | 0.64 | Track and gather more evidence |
+| options/locale_next/locale_en-US.json | high | 1.0 | Investigate and adversarially review |
+| go.sum | medium | 0.83 | Track and gather more evidence |
+| go.mod | medium | 0.83 | Track and gather more evidence |
+
+## Contributor Concentration
+
+| Author | Commits | Share |
+| --- | ---: | ---: |
+| Renovate Bot | 12 | 30.0% |
+| Mathieu Fenniak | 5 | 13.0% |
+| Robert Wolff | 3 | 8.0% |
+| Shiny Nematoda | 3 | 8.0% |
+| Gusted | 2 | 5.0% |
+
+## Path Hotspots
+
+| Path | Mentions |
+| --- | ---: |
+| `options/locale_next/locale_en-US.json` | 6 |
+| `go.sum` | 5 |
+| `go.mod` | 5 |
+| `package-lock.json` | 4 |
+| `routers/web/web.go` | 4 |
+| `package.json` | 3 |
+| `templates/user/settings/authorized_integrations.tmpl` | 3 |
+| `tests/e2e/user-settings.test.e2e.ts` | 3 |
+
+## Recent Commit Sample
+
+| When | Author | SHA |
+| --- | --- | --- |
+| 2026-05-22 | B0sh | `e49cb9e7` |
+| 2026-05-22 | hwipl | `1ea5605e` |
+| 2026-05-22 | Renovate Bot | `7054075b` |
+| 2026-05-22 | Renovate Bot | `ede3bbe6` |
+| 2026-05-22 | Maxim Cournoyer | `8dd01fa8` |
+| 2026-05-22 | Gusted | `4131cc41` |
+| 2026-05-22 | Renovate Bot | `294952b7` |
+| 2026-05-21 | Shiny Nematoda | `9ba57d58` |
+| 2026-05-21 | guillermodotn | `93638e11` |
+| 2026-05-21 | famfo | `b87dfe13` |
+| 2026-05-21 | Robert Wolff | `96b31a9a` |
+| 2026-05-21 | Renovate Bot | `7d0bac4b` |
+
+## Maintainer Bottleneck Notes
+
+- The strongest likely maintenance anchor in the sampled window is **Renovate Bot**, which makes continuity risk visible even before any explicit social graph is modeled.
+- The hottest code surface is `options/locale_next/locale_en-US.json`, which is a plausible place to focus future vouch-graph or review-latency instrumentation.
+- This first PoC still uses sampled commit topology and concentration signals as a stand-in for a fuller vouch network; it is meant to be shareable now, not final theory-complete infrastructure.

--- a/reports/public-repo-sna/kubernetes.md
+++ b/reports/public-repo-sna/kubernetes.md
@@ -1,0 +1,80 @@
+# kubernetes/kubernetes — Project Mind Report
+
+> Generated 2026-05-22T13:32:48.893689Z
+
+Subsystem sprawl with highly specialized reviewer clusters.
+
+## Executive Summary
+
+The investor story is not just repo analytics. Vaglio shows where controller, API machinery, and release engineering knowledge is concentrated, and where agent output needs durable provenance to stay governable.
+
+## Shareable Observations
+
+- `kubernetes/kubernetes` shows `medium` sampled contributor concentration, with the top three authors accounting for 45.0% of sampled commits.
+- The hottest sampled path is `pkg/registry/resource/resourcepoolstatusrequest/strategy.go` with `2` mentions in the shallow branch window.
+- `Kubernetes Prow Robot` leads the sampled window, indicating a repeat maintainer anchor rather than flatly distributed ownership.
+
+## Stress Surface
+
+- Branch stress: `0.69`
+- History heat: `4 peaks`
+- Active-inference confidence: `high`
+- Sampled contributor concentration: `medium`
+- Sampled top-author share: `45.0%`
+
+## Project Mind Heatmap
+
+| Surface | Stress | Heat | Appraisal |
+| --- | --- | --- | --- |
+| api machinery path | high | 0.84 | Investigate and adversarially review |
+| controller logic path | high | 0.79 | Investigate and adversarially review |
+| release tooling path | medium | 0.66 | Track and gather more evidence |
+| pkg/registry/resource/resourcepoolstatusrequest/strategy.go | high | 1.0 | Investigate and adversarially review |
+| staging/src/k8s.io/apiserver/pkg/features/kube_features.go | high | 1.0 | Investigate and adversarially review |
+| staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go | high | 1.0 | Investigate and adversarially review |
+
+## Contributor Concentration
+
+| Author | Commits | Share |
+| --- | ---: | ---: |
+| Kubernetes Prow Robot | 3296 | 39.0% |
+| Patrick Ohly | 345 | 4.0% |
+| Davanum Srinivas | 147 | 2.0% |
+| Joe Betz | 127 | 2.0% |
+| yongruilin | 116 | 1.0% |
+
+## Path Hotspots
+
+| Path | Mentions |
+| --- | ---: |
+| `pkg/registry/resource/resourcepoolstatusrequest/strategy.go` | 2 |
+| `staging/src/k8s.io/apiserver/pkg/features/kube_features.go` | 2 |
+| `staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go` | 2 |
+| `staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go` | 2 |
+| `hack/golangci-hints.yaml` | 1 |
+| `hack/golangci.yaml` | 1 |
+| `hack/kube-api-linter/exceptions.yaml` | 1 |
+| `pkg/api/testing/validation.go` | 1 |
+
+## Recent Commit Sample
+
+| When | Author | SHA |
+| --- | --- | --- |
+| 2026-05-21 | Kubernetes Prow Robot | `e136f393` |
+| 2026-05-21 | Kubernetes Prow Robot | `bfd1c1d5` |
+| 2026-05-21 | Kubernetes Prow Robot | `96914184` |
+| 2026-05-21 | Kubernetes Prow Robot | `323e8951` |
+| 2026-05-21 | Deepak Anand | `ef0f2288` |
+| 2026-05-21 | Kubernetes Prow Robot | `441eccd7` |
+| 2026-05-21 | Yongrui Lin | `6bf5c1bf` |
+| 2026-05-21 | Yongrui Lin | `dd66e21d` |
+| 2026-05-21 | Kubernetes Prow Robot | `f176c7f2` |
+| 2026-05-21 | Kubernetes Prow Robot | `963c3107` |
+| 2026-05-21 | Kubernetes Prow Robot | `ea692abf` |
+| 2026-05-21 | Ismail Alidzhikov | `400f43e7` |
+
+## Maintainer Bottleneck Notes
+
+- The strongest likely maintenance anchor in the sampled window is **Kubernetes Prow Robot**, which makes continuity risk visible even before any explicit social graph is modeled.
+- The hottest code surface is `pkg/registry/resource/resourcepoolstatusrequest/strategy.go`, which is a plausible place to focus future vouch-graph or review-latency instrumentation.
+- This first PoC still uses sampled commit topology and concentration signals as a stand-in for a fuller vouch network; it is meant to be shareable now, not final theory-complete infrastructure.

--- a/reports/public-repo-sna/nixpkgs.md
+++ b/reports/public-repo-sna/nixpkgs.md
@@ -1,0 +1,69 @@
+# NixOS/nixpkgs — Project Mind Report
+
+> Generated 2026-05-22T13:33:18.110355Z
+
+Operational complexity with concentrated review bottlenecks.
+
+## Executive Summary
+
+Vaglio highlights which maintainers absorb the coordination load, where routing and platform changes pile up, and how much of the rollout reasoning is already captured versus still trapped in chat.
+
+## Shareable Observations
+
+- `NixOS/nixpkgs` shows `low` sampled contributor concentration, with the top three authors accounting for 30.0% of sampled commits.
+- The hottest sampled path is `pkgs/by-name/ra/radicle-desktop/package.nix` with `1` mentions in the shallow branch window.
+- `R. Ryantm` leads the sampled window, indicating a repeat maintainer anchor rather than flatly distributed ownership.
+
+## Stress Surface
+
+- Branch stress: `0.78`
+- History heat: `3 peaks`
+- Active-inference confidence: `medium`
+- Sampled contributor concentration: `low`
+- Sampled top-author share: `30.0%`
+
+## Project Mind Heatmap
+
+| Surface | Stress | Heat | Appraisal |
+| --- | --- | --- | --- |
+| router failover path | high | 0.86 | Investigate and adversarially review |
+| module evaluation path | high | 0.81 | Investigate and adversarially review |
+| release plumbing path | medium | 0.63 | Track and gather more evidence |
+| pkgs/by-name/ra/radicle-desktop/package.nix | high | 1.0 | Investigate and adversarially review |
+| pkgs/by-name/vi/visual-paradigm-ce/package.nix | high | 1.0 | Investigate and adversarially review |
+
+## Contributor Concentration
+
+| Author | Commits | Share |
+| --- | ---: | ---: |
+| R. Ryantm | 729 | 17.0% |
+| nixpkgs-ci[bot] | 417 | 10.0% |
+| Sandro | 129 | 3.0% |
+| Fabian Affolter | 100 | 2.0% |
+| Peder Bergebakken Sundt | 97 | 2.0% |
+
+## Path Hotspots
+
+| Path | Mentions |
+| --- | ---: |
+| `pkgs/by-name/ra/radicle-desktop/package.nix` | 1 |
+| `pkgs/by-name/vi/visual-paradigm-ce/package.nix` | 1 |
+
+## Recent Commit Sample
+
+| When | Author | SHA |
+| --- | --- | --- |
+| 2026-05-22 | nixpkgs-ci[bot] | `c88807e0` |
+| 2026-05-22 | Maximilian Bosch | `fbeb6bc8` |
+| 2026-05-22 | Pol Dellaiera | `8651b537` |
+| 2026-05-22 | Pol Dellaiera | `4fc0c18e` |
+| 2026-05-22 | Eli Saado | `d0eb5122` |
+| 2026-05-22 | Felix Bargfeldt | `647cb4a3` |
+| 2026-05-22 | nixpkgs-ci[bot] | `b322daaf` |
+| 2026-05-22 | Adam C. Stephens | `48296da2` |
+
+## Maintainer Bottleneck Notes
+
+- The strongest likely maintenance anchor in the sampled window is **R. Ryantm**, which makes continuity risk visible even before any explicit social graph is modeled.
+- The hottest code surface is `pkgs/by-name/ra/radicle-desktop/package.nix`, which is a plausible place to focus future vouch-graph or review-latency instrumentation.
+- This first PoC still uses sampled commit topology and concentration signals as a stand-in for a fuller vouch network; it is meant to be shareable now, not final theory-complete infrastructure.

--- a/roundtable/lib/mix/tasks/roundtable.sna_reports.ex
+++ b/roundtable/lib/mix/tasks/roundtable.sna_reports.ex
@@ -1,0 +1,38 @@
+defmodule Mix.Tasks.Roundtable.SnaReports do
+  @shortdoc "Export markdown SNA-style reports for the public demo repos"
+
+  use Mix.Task
+
+  alias Roundtable.PublicRepoSnaReports
+
+  @impl true
+  def run(args) do
+    Mix.Task.run("app.start")
+    opts = parse_args(args)
+
+    case PublicRepoSnaReports.export_all(opts) do
+      {:ok, paths} ->
+        Enum.each(paths, &Mix.shell().info("wrote #{&1}"))
+
+      {:error, reason} ->
+        Mix.raise("failed to export SNA reports: #{inspect(reason)}")
+    end
+  end
+
+  def parse_args(args) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args,
+        strict: [output_root: :string, snapshot_output_root: :string, base_url: :string]
+      )
+
+    if invalid != [] or positional != [] do
+      raise usage("unexpected arguments")
+    end
+
+    opts
+  end
+
+  defp usage(reason) do
+    "#{reason}\nusage: mix roundtable.sna_reports [--output-root <dir>] [--snapshot-output-root <dir>] [--base-url <url>]"
+  end
+end

--- a/roundtable/lib/roundtable/public_repo_sna_reports.ex
+++ b/roundtable/lib/roundtable/public_repo_sna_reports.ex
@@ -68,8 +68,6 @@ defmodule Roundtable.PublicRepoSnaReports do
   end
 
   defp export_repo_reports(output_root, opts) do
-    opts = Keyword.put_new(opts, :output_root, "reports/public-repo-demos")
-
     report_exports =
       for demo <- demo_ids() do
         with {:ok, snapshot} <- PublicRepoDemo.snapshot(demo, opts),
@@ -136,14 +134,17 @@ defmodule Roundtable.PublicRepoSnaReports do
     signals = history_summary.derived_signals
     hotspot = List.first(history_summary.path_hotspots)
     contributor = List.first(history_summary.top_contributors)
+    contributor_name = if contributor, do: contributor.author, else: "No dominant contributor"
+    hotspot_path = if hotspot, do: hotspot.path, else: "no sampled hotspot"
+    hotspot_mentions = if hotspot, do: hotspot.mentions, else: 0
 
     [
       "- `", snapshot.demo.name, "` shows `", signals.contributor_concentration,
       "` sampled contributor concentration, with the top three authors accounting for ",
       percentage(signals.top_author_share), " of sampled commits.\n",
-      "- The hottest sampled path is `", hotspot.path, "` with `", to_string(hotspot.mentions),
+      "- The hottest sampled path is `", hotspot_path, "` with `", to_string(hotspot_mentions),
       "` mentions in the shallow branch window.\n",
-      "- `", contributor.author, "` leads the sampled window, indicating a repeat maintainer anchor rather than flatly distributed ownership.\n"
+      "- `", contributor_name, "` leads the sampled window, indicating a repeat maintainer anchor rather than flatly distributed ownership.\n"
     ]
   end
 
@@ -197,6 +198,8 @@ defmodule Roundtable.PublicRepoSnaReports do
     end)
   end
 
+  defp derived_heatmap_rows(_), do: ""
+
   defp contributor_rows(history_summary) do
     total = max(history_summary.sampled_commit_count, 1)
 
@@ -235,11 +238,13 @@ defmodule Roundtable.PublicRepoSnaReports do
     history_summary = snapshot.source.history_summary
     hotspot = List.first(history_summary.path_hotspots)
     contributor = List.first(history_summary.top_contributors)
+    contributor_name = if contributor, do: contributor.author, else: "no single maintainer anchor"
+    hotspot_path = if hotspot, do: hotspot.path, else: "no sampled hotspot"
 
     [
-      "- The strongest likely maintenance anchor in the sampled window is **", contributor.author,
+      "- The strongest likely maintenance anchor in the sampled window is **", contributor_name,
       "**, which makes continuity risk visible even before any explicit social graph is modeled.\n",
-      "- The hottest code surface is `", hotspot.path,
+      "- The hottest code surface is `", hotspot_path,
       "`, which is a plausible place to focus future vouch-graph or review-latency instrumentation.\n",
       "- This first PoC still uses sampled commit topology and concentration signals as a stand-in for a fuller vouch network; it is meant to be shareable now, not final theory-complete infrastructure.\n"
     ]

--- a/roundtable/lib/roundtable/public_repo_sna_reports.ex
+++ b/roundtable/lib/roundtable/public_repo_sna_reports.ex
@@ -1,0 +1,278 @@
+defmodule Roundtable.PublicRepoSnaReports do
+  @moduledoc """
+  Builds shareable markdown reports for the public repo demo snapshots.
+  """
+
+  alias Roundtable.PublicRepoDemo
+
+  @type options :: keyword()
+
+  @default_output_root "reports/public-repo-sna"
+
+  @spec export_all(options()) :: {:ok, [Path.t()]} | {:error, term()}
+  def export_all(opts \\ []) do
+    output_root = Keyword.get(opts, :output_root, @default_output_root)
+
+    with :ok <- File.mkdir_p(output_root),
+         {:ok, report_exports} <- export_repo_reports(output_root, opts),
+         {:ok, index_path} <- export_index(output_root, report_exports) do
+      report_paths = Enum.map(report_exports, & &1.path)
+      {:ok, [index_path | report_paths]}
+    end
+  end
+
+  @spec render_report(map()) :: String.t()
+  def render_report(snapshot) do
+    history_summary = snapshot.source.history_summary
+    signals = history_summary.derived_signals
+
+    [
+      "# ", snapshot.demo.name, " — Project Mind Report\n\n",
+      "> Generated ", snapshot.generated_at, "\n\n",
+      snapshot.dashboard.headline, "\n\n",
+      "## Executive Summary\n\n",
+      snapshot.dashboard.narrative, "\n\n",
+      "## Shareable Observations\n\n",
+      observation_bullets(snapshot),
+      "\n",
+      "## Stress Surface\n\n",
+      "- Branch stress: `", metric_value(snapshot.dashboard.stress.metrics, "Branch stress"), "`\n",
+      "- History heat: `", metric_value(snapshot.dashboard.stress.metrics, "History heat"), "`\n",
+      "- Active-inference confidence: `", metric_value(snapshot.dashboard.stress.metrics, "Active-inference confidence"), "`\n",
+      "- Sampled contributor concentration: `", signals.contributor_concentration, "`\n",
+      "- Sampled top-author share: `", percentage(signals.top_author_share), "`\n\n",
+      "## Project Mind Heatmap\n\n",
+      "| Surface | Stress | Heat | Appraisal |\n",
+      "| --- | --- | --- | --- |\n",
+      heatmap_rows(snapshot),
+      "\n",
+      "## Contributor Concentration\n\n",
+      "| Author | Commits | Share |\n",
+      "| --- | ---: | ---: |\n",
+      contributor_rows(history_summary),
+      "\n",
+      "## Path Hotspots\n\n",
+      "| Path | Mentions |\n",
+      "| --- | ---: |\n",
+      hotspot_rows(history_summary.path_hotspots),
+      "\n",
+      "## Recent Commit Sample\n\n",
+      "| When | Author | SHA |\n",
+      "| --- | --- | --- |\n",
+      commit_rows(history_summary.recent_commits),
+      "\n",
+      "## Maintainer Bottleneck Notes\n\n",
+      bottleneck_notes(snapshot)
+    ]
+    |> IO.iodata_to_binary()
+  end
+
+  defp export_repo_reports(output_root, opts) do
+    opts = Keyword.put_new(opts, :output_root, "reports/public-repo-demos")
+
+    report_exports =
+      for demo <- demo_ids() do
+        with {:ok, snapshot} <- PublicRepoDemo.snapshot(demo, opts),
+             :ok <- maybe_export_snapshot(snapshot, opts),
+             path <- Path.join(output_root, "#{demo}.md"),
+             :ok <- File.write(path, render_report(snapshot)) do
+          {:ok,
+           %{
+             id: snapshot.demo.id,
+             name: snapshot.demo.name,
+             generated_at: snapshot.generated_at,
+             path: path
+           }}
+        end
+      end
+
+    case Enum.find(report_exports, &match?({:error, _}, &1)) do
+      nil -> {:ok, Enum.map(report_exports, fn {:ok, report} -> report end)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp export_index(output_root, report_exports) do
+    body =
+      [
+        "# Public Repo SNA Reports\n\n",
+        "This directory contains shareable markdown artifacts derived from the same public repo snapshots that drive `/forgejo-shell` and `/forgejo-shell/reports`.\n\n",
+        "| Repo | Generated | Report |\n",
+        "| --- | --- | --- |\n",
+        Enum.map(Enum.sort_by(report_exports, & &1.name), fn report ->
+          [
+            "| ",
+            report.name,
+            " | ",
+            report.generated_at,
+            " | [",
+            report.id,
+            "](./",
+            report.id,
+            ".md) |\n"
+          ]
+        end)
+      ]
+      |> IO.iodata_to_binary()
+
+    path = Path.join(output_root, "README.md")
+    File.write(path, body)
+    {:ok, path}
+  end
+
+  defp maybe_export_snapshot(snapshot, opts) do
+    output_root = Keyword.get(opts, :snapshot_output_root, "reports/public-repo-demos")
+    path = Path.join(output_root, "#{snapshot.demo.id}.json")
+
+    with :ok <- File.mkdir_p(output_root),
+         {:ok, encoded} <- Jason.encode_to_iodata(snapshot, pretty: true),
+         :ok <- File.write(path, encoded) do
+      :ok
+    end
+  end
+
+  defp observation_bullets(snapshot) do
+    history_summary = snapshot.source.history_summary
+    signals = history_summary.derived_signals
+    hotspot = List.first(history_summary.path_hotspots)
+    contributor = List.first(history_summary.top_contributors)
+
+    [
+      "- `", snapshot.demo.name, "` shows `", signals.contributor_concentration,
+      "` sampled contributor concentration, with the top three authors accounting for ",
+      percentage(signals.top_author_share), " of sampled commits.\n",
+      "- The hottest sampled path is `", hotspot.path, "` with `", to_string(hotspot.mentions),
+      "` mentions in the shallow branch window.\n",
+      "- `", contributor.author, "` leads the sampled window, indicating a repeat maintainer anchor rather than flatly distributed ownership.\n"
+    ]
+  end
+
+  defp heatmap_rows(snapshot) do
+    history_summary = snapshot.source.history_summary
+    derived = derived_heatmap_rows(history_summary)
+
+    curated =
+      snapshot.dashboard.stress.hotspots
+      |> Enum.map(fn hotspot ->
+        [
+          "| ",
+          hotspot.title,
+          " | ",
+          hotspot.stress,
+          " | ",
+          to_string(hotspot.heat),
+          " | ",
+          appraisal_for(hotspot.stress),
+          " |\n"
+        ]
+      end)
+
+    IO.iodata_to_binary([curated, derived])
+  end
+
+  defp derived_heatmap_rows(%{path_hotspots: hotspots, derived_signals: signals}) do
+    max_mentions =
+      hotspots
+      |> Enum.map(& &1.mentions)
+      |> Enum.max(fn -> 1 end)
+      |> max(1)
+
+    hotspots
+    |> Enum.take(3)
+    |> Enum.map(fn hotspot ->
+      heat = Float.round(hotspot.mentions / max_mentions, 2)
+      stress = derived_stress(heat, signals.contributor_concentration)
+
+      [
+        "| ",
+        hotspot.path,
+        " | ",
+        stress,
+        " | ",
+        Float.to_string(heat),
+        " | ",
+        appraisal_for(stress),
+        " |\n"
+      ]
+    end)
+  end
+
+  defp contributor_rows(history_summary) do
+    total = max(history_summary.sampled_commit_count, 1)
+
+    history_summary.top_contributors
+    |> Enum.map(fn contributor ->
+      [
+        "| ",
+        contributor.author,
+        " | ",
+        to_string(contributor.commits),
+        " | ",
+        percentage(contributor.commits / total),
+        " |\n"
+      ]
+    end)
+    |> IO.iodata_to_binary()
+  end
+
+  defp hotspot_rows(hotspots) do
+    hotspots
+    |> Enum.map(fn hotspot ->
+      ["| `", hotspot.path, "` | ", to_string(hotspot.mentions), " |\n"]
+    end)
+    |> IO.iodata_to_binary()
+  end
+
+  defp commit_rows(commits) do
+    commits
+    |> Enum.map(fn commit ->
+      ["| ", commit_day(commit.committed_at_unix), " | ", commit.author, " | `", short_sha(commit.sha), "` |\n"]
+    end)
+    |> IO.iodata_to_binary()
+  end
+
+  defp bottleneck_notes(snapshot) do
+    history_summary = snapshot.source.history_summary
+    hotspot = List.first(history_summary.path_hotspots)
+    contributor = List.first(history_summary.top_contributors)
+
+    [
+      "- The strongest likely maintenance anchor in the sampled window is **", contributor.author,
+      "**, which makes continuity risk visible even before any explicit social graph is modeled.\n",
+      "- The hottest code surface is `", hotspot.path,
+      "`, which is a plausible place to focus future vouch-graph or review-latency instrumentation.\n",
+      "- This first PoC still uses sampled commit topology and concentration signals as a stand-in for a fuller vouch network; it is meant to be shareable now, not final theory-complete infrastructure.\n"
+    ]
+  end
+
+  defp metric_value(metrics, label) do
+    metrics
+    |> Enum.find(%{}, &(&1.label == label))
+    |> Map.get(:value, "n/a")
+    |> to_string()
+  end
+
+  defp derived_stress(heat, "high") when heat >= 0.66, do: "high"
+  defp derived_stress(heat, _) when heat >= 0.85, do: "high"
+  defp derived_stress(heat, _) when heat >= 0.45, do: "medium"
+  defp derived_stress(_, _), do: "low"
+
+  defp appraisal_for("high"), do: "Investigate and adversarially review"
+  defp appraisal_for("medium"), do: "Track and gather more evidence"
+  defp appraisal_for("low"), do: "Low urgency, preserve context"
+  defp appraisal_for(_), do: "Track and gather more evidence"
+
+  defp percentage(value) when is_float(value), do: "#{Float.round(value * 100, 0)}%"
+
+  defp commit_day(unix) do
+    unix
+    |> DateTime.from_unix!()
+    |> Calendar.strftime("%Y-%m-%d")
+  end
+
+  defp short_sha(sha), do: String.slice(sha, 0, 8)
+
+  defp demo_ids do
+    ["forgejo", "kubernetes", "nixpkgs"]
+  end
+end

--- a/roundtable/test/roundtable/public_repo_sna_reports_test.exs
+++ b/roundtable/test/roundtable/public_repo_sna_reports_test.exs
@@ -1,0 +1,81 @@
+defmodule Roundtable.PublicRepoSnaReportsTest do
+  use ExUnit.Case, async: true
+
+  alias Roundtable.{PublicRepoDemo, PublicRepoSnaReports}
+
+  defmodule FakeCommandRunner do
+    @behaviour Roundtable.CommandRunner
+    @handler_key {__MODULE__, :handler}
+
+    @impl true
+    def cmd(command, args, opts) do
+      handler = :persistent_term.get(@handler_key, nil) || raise "missing fake command handler"
+      handler.(command, args, opts)
+    end
+  end
+
+  setup do
+    :persistent_term.put({FakeCommandRunner, :handler}, fn
+      "git", ["ls-remote", _clone_url, "HEAD", tracked_ref], _opts ->
+        {"123abc\tHEAD\n456def\t#{tracked_ref}\n", 0}
+
+      "git", ["init", _repo_dir], _opts ->
+        {"Initialized empty Git repository\n", 0}
+
+      "git", ["-C", _repo_dir, "remote", "add", "origin", _clone_url], _opts ->
+        {"", 0}
+
+      "git", ["-C", _repo_dir, "fetch", "--depth", _depth, "origin", _tracked_ref], _opts ->
+        {"", 0}
+
+      "git", ["-C", _repo_dir, "rev-list", "--count", "FETCH_HEAD"], _opts ->
+        {"40\n", 0}
+
+      "git", ["-C", _repo_dir, "shortlog", "-sne", "FETCH_HEAD"], _opts ->
+        {"   22  Alice Example <alice@example.com>\n   11  Bob Example <bob@example.com>\n    7  Carol Example <carol@example.com>\n", 0}
+
+      "git", ["-C", _repo_dir, "log", "--format=%ct\t%an\t%H", "--max-count=" <> _limit, "FETCH_HEAD"], _opts ->
+        {"1715616000\tAlice Example\tdeadbeef\n1715529600\tBob Example\tcafebabe\n", 0}
+
+      "git", ["-C", _repo_dir, "log", "--format=", "--name-only", "--max-count=" <> _limit, "FETCH_HEAD"], _opts ->
+        {"pkg/a\npkg/a\npkg/b\n", 0}
+    end)
+
+    :ok
+  end
+
+  test "renders a markdown report from a snapshot" do
+    assert {:ok, snapshot} =
+             PublicRepoDemo.snapshot("forgejo",
+               runner: FakeCommandRunner,
+               generated_at: "2026-05-22T13:00:00Z"
+             )
+
+    report = PublicRepoSnaReports.render_report(snapshot)
+
+    assert report =~ "# forgejo/forgejo — Project Mind Report"
+    assert report =~ "## Project Mind Heatmap"
+    assert report =~ "## Contributor Concentration"
+    assert report =~ "## Path Hotspots"
+    assert report =~ "Investigate and adversarially review"
+    assert report =~ "Alice Example"
+  end
+
+  test "exports a markdown bundle and index" do
+    output_root = Path.join(System.tmp_dir!(), "roundtable-sna-reports-#{System.unique_integer()}")
+    snapshot_output_root = Path.join(System.tmp_dir!(), "roundtable-sna-snapshots-#{System.unique_integer()}")
+
+    assert {:ok, paths} =
+             PublicRepoSnaReports.export_all(
+               runner: FakeCommandRunner,
+               output_root: output_root,
+               snapshot_output_root: snapshot_output_root
+             )
+
+    assert Enum.any?(paths, &String.ends_with?(&1, "README.md"))
+    assert File.exists?(Path.join(output_root, "forgejo.md"))
+    assert File.exists?(Path.join(output_root, "kubernetes.md"))
+    assert File.exists?(Path.join(output_root, "nixpkgs.md"))
+    assert File.exists?(Path.join(snapshot_output_root, "forgejo.json"))
+  end
+end

--- a/roundtable/test/roundtable/public_repo_sna_reports_test.exs
+++ b/roundtable/test/roundtable/public_repo_sna_reports_test.exs
@@ -1,5 +1,5 @@
 defmodule Roundtable.PublicRepoSnaReportsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Roundtable.{PublicRepoDemo, PublicRepoSnaReports}
 
@@ -77,5 +77,42 @@ defmodule Roundtable.PublicRepoSnaReportsTest do
     assert File.exists?(Path.join(output_root, "kubernetes.md"))
     assert File.exists?(Path.join(output_root, "nixpkgs.md"))
     assert File.exists?(Path.join(snapshot_output_root, "forgejo.json"))
+  end
+
+  test "renders safely when sampled hotspots or contributors are empty" do
+    snapshot = %{
+      generated_at: "2026-05-22T13:00:00Z",
+      demo: %{id: "demo", name: "demo/repo"},
+      source: %{
+        history_summary: %{
+          sampled_commit_count: 0,
+          contributor_count: 0,
+          top_contributors: [],
+          path_hotspots: [],
+          recent_commits: [],
+          derived_signals: %{
+            contributor_concentration: "low",
+            top_author_share: 0.0
+          }
+        }
+      },
+      dashboard: %{
+        headline: "headline",
+        narrative: "narrative",
+        stress: %{
+          metrics: [
+            %{label: "Branch stress", value: "0.10"},
+            %{label: "History heat", value: "1 peak"},
+            %{label: "Active-inference confidence", value: "low"}
+          ],
+          hotspots: []
+        }
+      }
+    }
+
+    report = PublicRepoSnaReports.render_report(snapshot)
+
+    assert report =~ "no sampled hotspot"
+    assert report =~ "No dominant contributor"
   end
 end


### PR DESCRIPTION
## Summary
- claim work item 60 and add a reproducible markdown report generator for the public demo repos
- export checked-in JSON snapshots under reports/public-repo-demos and shareable markdown reports under reports/public-repo-sna
- cover the report renderer and bundle exporter with focused tests

## Testing
- nix develop . --command bash -lc 'cd roundtable && mix test test/roundtable/public_repo_demo_test.exs test/roundtable/public_repo_demo_report_entries_test.exs test/roundtable/public_repo_sna_reports_test.exs test/roundtable_web/forgejo_shell_reports_live_test.exs'
- nix develop . --command bash -lc 'cd roundtable && mix roundtable.sna_reports --output-root ../reports/public-repo-sna --snapshot-output-root ../reports/public-repo-demos'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated shareable analytics reports for three public repositories (Forgejo, Kubernetes, NixOS/nixpkgs) including contributor concentration metrics, code hotspot analysis, stress indicators, and recent commit samples.

* **Documentation**
  * Added report index and guide documenting the generated public project analyses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/agent-roundtable/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->