### PR TITLE
docs: codify resource contention policy

### DIFF
--- a/docs/design/BOARD_EXECUTION_MODEL.md
+++ b/docs/design/BOARD_EXECUTION_MODEL.md
@@ -191,6 +191,33 @@ Reusable policy bundles referenced by `work_items.workflow_ref`.
 
 ---
 
+## 3.7 Future resource-claim extension
+
+Current board leases attach to work attempts. That is necessary, but it is not
+enough to prevent two runtimes from mutating the same live resource at once.
+
+The next board-side step should treat resource affinity and contention as
+structured data on the work item or workflow, not only as prose in queue docs.
+The expected fields are:
+
+| Field | Meaning |
+|---|---|
+| `contention_class` | Resource class such as `branch_workspace`, `read_only_shared`, `mutable_live_host`, `shared_data_plane`, or `control_plane` |
+| `resource_scope` | Concrete target such as `host:vaglio`, `cache:public-repo-demo`, `db:board-main`, or `branch:feature-x` |
+| `exclusive_lease_required` | Whether mutation of that scope must be single-writer |
+| `concurrent_read_safe` | Whether read-only actions on the same scope may proceed in parallel |
+
+This project should treat `host:vaglio` as the canonical example:
+
+- read-only preflight and inspection may run concurrently
+- `nixos-rebuild switch`, service restarts, and cache warm jobs on the same host
+  should require exclusive ownership
+
+This keeps branch-parallelism intact while giving the board a path toward
+resource-level leases in addition to work-item leases.
+
+---
+
 ## 4. Work-item lifecycle
 
 The board state machine should be explicit.

--- a/docs/design/LOCAL_DAEMON_CONTRACT.md
+++ b/docs/design/LOCAL_DAEMON_CONTRACT.md
@@ -170,6 +170,26 @@ This prevents “ghost ownership” when:
 - the daemon crashes
 - network connectivity is lost
 
+### Future resource-level lease note
+
+Work-item leases are not the full contention model. The daemon and board should
+eventually understand whether a claim is:
+
+- branch-local and safe to run in parallel
+- read-only against a shared target
+- mutating a live resource that requires exclusivity
+
+The expected future inputs are resource-oriented rather than repo-oriented:
+
+- `contention_class`
+- `resource_scope`
+- `exclusive_lease_required`
+
+That distinction matters because two agents can safely work on unrelated
+branches of the same repo while still being unsafe to run `nixos-rebuild
+switch`, `systemctl restart`, or cache-warming jobs against the same host at
+the same time.
+
 ---
 
 ## 7. Attempt event model

--- a/docs/work-items/76-standalone-vaglio-service-hardening.md
+++ b/docs/work-items/76-standalone-vaglio-service-hardening.md
@@ -3,7 +3,7 @@
 Status: `done`
 Suggested branch: `fix/standalone-vaglio-service-hardening`
 Deployment target: `vaglio`
-Deployment coordination: `exclusive single-writer host lock while live deploy work is active`
+Deployment coordination: `exclusive single-writer live-resource mutation lock while live deploy work is active`
 
 ## Goal
 

--- a/docs/work-items/77-large-demo-prewarm-scaling.md
+++ b/docs/work-items/77-large-demo-prewarm-scaling.md
@@ -3,7 +3,7 @@
 Status: `done`
 Suggested branch: `fix/large-demo-prewarm-scaling`
 Deployment target: `vaglio`
-Deployment coordination: `exclusive single-writer host lock while live deploy work is active`
+Deployment coordination: `exclusive single-writer live-resource mutation lock while live deploy work is active`
 
 ## Goal
 

--- a/docs/work-items/78-resource-contention-and-single-writer-policy.md
+++ b/docs/work-items/78-resource-contention-and-single-writer-policy.md
@@ -1,6 +1,6 @@
 # 78 — Resource Contention and Single-Writer Policy
 
-**Status:** `in-progress` — **Codex**
+**Status:** `done` — **Codex**
 **Tag:** `[structural]`
 
 ## Goal
@@ -43,3 +43,15 @@ read-only analysis.
 
 - Primary design source: `docs/design/rounds/round-88-agent-resource-contention.md`
 - This item is about coordination semantics, not broad host-wide locking.
+
+## Outcome
+
+- Added a resource-class table to `docs/work-items/README.md` that distinguishes
+  concurrent-safe actions from exclusive actions.
+- Codified the `vaglio` rule as a live-resource mutation lock rather than a
+  blanket host lock.
+- Added explicit future resource-claim / resource-lease notes to:
+  - `docs/design/BOARD_EXECUTION_MODEL.md`
+  - `docs/design/LOCAL_DAEMON_CONTRACT.md`
+- Updated adjacent `vaglio` deployment items to use the narrower
+  live-resource-mutation wording.

--- a/docs/work-items/78-resource-contention-and-single-writer-policy.md
+++ b/docs/work-items/78-resource-contention-and-single-writer-policy.md
@@ -1,6 +1,6 @@
 # 78 — Resource Contention and Single-Writer Policy
 
-**Status:** `ready`
+**Status:** `in-progress` — **Codex**
 **Tag:** `[structural]`
 
 ## Goal
@@ -43,4 +43,3 @@ read-only analysis.
 
 - Primary design source: `docs/design/rounds/round-88-agent-resource-contention.md`
 - This item is about coordination semantics, not broad host-wide locking.
-

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -172,7 +172,7 @@ Do not work on an item already marked `in-progress` by another agent.
 ### Prediction Calibration & Resource Coordination (Rounds 87-88)
 
 66. [`77-jj-prediction-calibration-protocol.md`](./77-jj-prediction-calibration-protocol.md) — `ready` — `[integrity]` `jj` prediction metadata and outcome-linked calibration
-67. [`78-resource-contention-and-single-writer-policy.md`](./78-resource-contention-and-single-writer-policy.md) — `ready` — `[structural]` Resource classes and live mutation single-writer policy
+67. [`78-resource-contention-and-single-writer-policy.md`](./78-resource-contention-and-single-writer-policy.md) — `in-progress` — **Codex** — `[structural]` Resource classes and live mutation single-writer policy
 
 ### Canonical Markdown + Derived Structure (Round 89)
 

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -36,6 +36,24 @@ Do not work on an item already marked `in-progress` by another agent.
 - Do not treat a live-resource lock as a general ban on all work related to that
   repo or host.
 
+## Resource classes
+
+| Resource type | Examples | Concurrent-safe actions | Exclusive actions |
+|---|---|---|---|
+| Branch-local workspace | `jj` change, git branch, local patch queue, isolated temp checkout | edit code, run local tests, generate docs, compare branches | force-push / rewrite on the same shared branch, destructive cleanup of another agent's workspace |
+| Read-only shared resource | logs, config snapshots, status endpoints, board records, repo inspection | `journalctl`, `curl`, `git show`, `gh pr view`, metrics inspection | rate-limited or operator-declared fragile probes |
+| Append-only shared state | work-attempt events, report exports, immutable artifacts, discussion transcripts | append events, add reports, record observations | destructive compaction, retroactive mutation, schema-breaking rewrites |
+| Mutable live service host / VM | `vaglio`, staging VM, long-lived NixOS target | read-only preflight, status checks, smoke probes | `nixos-rebuild switch`, service restart, runtime override edit, cache warm, mutable deploy hooks |
+| Shared service data plane | cache namespace, warmed snapshot store, database schema, live queue backend | read-only queries, export, verification | migrations, invalidation, reindex, cache purge, warm jobs with shared side effects |
+| Risky control-plane target | DNS cutover, failover drill, power state, network identity promotion | dry-run planning, read-only validation | failover, power cycle, role promotion, identity reassignment |
+
+The important rule is action class plus resource class:
+
+- read-only work on a host is often concurrent-safe
+- branch-local code work is concurrent-safe by default
+- mutating actions on the same live resource require a single current owner
+- `vaglio` is therefore a live-resource mutation lock, not a general branch-work lock
+
 ## Queue
 
 84. [`82-hosted-analysis-provider-contract.md`](./82-hosted-analysis-provider-contract.md) — `ready` — `[product]` Hosted analysis provider contract
@@ -172,7 +190,7 @@ Do not work on an item already marked `in-progress` by another agent.
 ### Prediction Calibration & Resource Coordination (Rounds 87-88)
 
 66. [`77-jj-prediction-calibration-protocol.md`](./77-jj-prediction-calibration-protocol.md) — `ready` — `[integrity]` `jj` prediction metadata and outcome-linked calibration
-67. [`78-resource-contention-and-single-writer-policy.md`](./78-resource-contention-and-single-writer-policy.md) — `in-progress` — **Codex** — `[structural]` Resource classes and live mutation single-writer policy
+67. [`78-resource-contention-and-single-writer-policy.md`](./78-resource-contention-and-single-writer-policy.md) — `done` — **Codex** — `[structural]` Resource classes and live mutation single-writer policy
 
 ### Canonical Markdown + Derived Structure (Round 89)
 


### PR DESCRIPTION
## Summary\n- add a concrete resource-class table to the work-item queue docs\n- define the vaglio rule as a live-resource mutation lock rather than a blanket host lock\n- add future board/daemon notes for resource-level lease metadata\n\n## Testing\n- git diff --check\n