### PR TITLE
docs: specify round metadata index

### DIFF
--- a/docs/design/BOARD_EXECUTION_MODEL.md
+++ b/docs/design/BOARD_EXECUTION_MODEL.md
@@ -100,6 +100,10 @@ One row per dispatchable unit of work.
 | `retry_policy` | json | Max attempts, backoff, retryable failures |
 | `timeout_policy` | json | Soft / hard timeout and timeout action |
 | `hitl_policy` | json nullable | Approval / escalation / review gate configuration |
+| `contention_class` | text nullable | Resource class such as `branch_workspace`, `read_only_shared`, or `mutable_live_host` |
+| `resource_scope` | text nullable | Concrete scope such as `host:vaglio`, `cache:public-repo-demo`, or `branch:feature-x` |
+| `exclusive_lease_required` | boolean | Whether mutating this scope requires a single current owner |
+| `concurrent_read_safe` | boolean | Whether read-only actions on this scope may proceed in parallel |
 | `created_at` | timestamp | Creation time |
 | `updated_at` | timestamp | Last mutation |
 | `closed_at` | timestamp nullable | Terminal completion time |
@@ -186,19 +190,21 @@ Reusable policy bundles referenced by `work_items.workflow_ref`.
 | `timeout_policy_json` | json nullable | Reusable timeout policy defaults |
 | `hitl_policy_json` | json nullable | Reusable human-gate defaults |
 | `resume_policy_json` | json nullable | Reusable post-approval resume defaults |
+| `default_contention_class` | text nullable | Default resource class for tasks using this workflow |
+| `default_resource_scope_template` | text nullable | Templated resource scope such as `host:{host_label}` or `cache:{dataset}` |
+| `default_exclusive_lease_required` | boolean nullable | Whether the workflow normally requires a single-writer mutation lease |
 | `created_at` | timestamp | Creation time |
 | `updated_at` | timestamp | Last mutation |
 
 ---
 
-## 3.7 Future resource-claim extension
+## 3.7 Resource-claim fields and authority split
 
-Current board leases attach to work attempts. That is necessary, but it is not
-enough to prevent two runtimes from mutating the same live resource at once.
+Current board leases attach to work attempts. That remains necessary, but it is
+not enough to prevent two runtimes from mutating the same live resource at once.
 
-The next board-side step should treat resource affinity and contention as
-structured data on the work item or workflow, not only as prose in queue docs.
-The expected fields are:
+The board should therefore treat resource affinity and contention as structured
+data on the work item or workflow, not only as prose in queue docs.
 
 | Field | Meaning |
 |---|---|
@@ -207,14 +213,22 @@ The expected fields are:
 | `exclusive_lease_required` | Whether mutation of that scope must be single-writer |
 | `concurrent_read_safe` | Whether read-only actions on the same scope may proceed in parallel |
 
+These fields are operational state, not memory/archive state.
+
+The authority split should remain:
+
+- markdown rounds describe the policy and rationale
+- the derived round index exposes those rounds for search/query
+- board tables enforce the live resource claim semantics
+
 This project should treat `host:vaglio` as the canonical example:
 
 - read-only preflight and inspection may run concurrently
 - `nixos-rebuild switch`, service restarts, and cache warm jobs on the same host
   should require exclusive ownership
 
-This keeps branch-parallelism intact while giving the board a path toward
-resource-level leases in addition to work-item leases.
+This keeps branch-parallelism intact while making resource-level leases a
+first-class board concern rather than a future prose-only reminder.
 
 ---
 

--- a/docs/design/ROUND_METADATA_INDEX.md
+++ b/docs/design/ROUND_METADATA_INDEX.md
@@ -1,0 +1,146 @@
+# Round Metadata Index
+
+**Status:** Drafted from Rounds 73, 74, and 89  
+**Purpose:** Define the derived metadata surface for round archives while
+keeping markdown as the canonical design-memory layer.
+
+---
+
+## 1. Canonical split
+
+Round markdown remains the source of truth for:
+
+- title and long-form rationale
+- disagreement and synthesis
+- legitimacy / audit review
+
+The round metadata index is a **derived query surface**. It exists so agents and
+tools can query tags, status, and related-round links without scanning every
+markdown file on every request.
+
+This document does **not** make the index canonical. If the index and markdown
+diverge, the markdown wins and the index must be regenerated.
+
+---
+
+## 2. Extraction target
+
+The recommended derived artifact is a JSONL file plus small derived views:
+
+- `derived/round-index/rounds.jsonl`
+- `derived/round-index/tags.json`
+- `derived/round-index/related-rounds.json`
+
+`rounds.jsonl` is the canonical derived artifact. The other files are optional
+materialized views built from it.
+
+---
+
+## 3. Record shape
+
+Each round file should extract to one JSON object with this minimum shape:
+
+```json
+{
+  "round_id": "round-89-markdown-canonical-derived-structure",
+  "round_number": 89,
+  "source_path": "docs/design/rounds/round-89-markdown-canonical-derived-structure.md",
+  "title": "Markdown as Canonical Memory, Structured Indices, and Board-Integrated Resource Claims",
+  "status": "Closed",
+  "tags": ["structural", "tooling", "epistemic-integrity", "governance"],
+  "voices_used": ["Copilot synthesis", "local repo grounding"],
+  "related_rounds": [62, 73, 74, 85, 87, 88],
+  "source_kind": "round",
+  "derived_from_markdown": true
+}
+```
+
+### Field meanings
+
+| Field | Meaning |
+|---|---|
+| `round_id` | Stable identifier derived from filename |
+| `round_number` | Numeric round number when present; nullable for special cases |
+| `source_path` | Markdown path that remains canonical |
+| `title` | Human title extracted from the first heading |
+| `status` | Round status such as `Closed` |
+| `tags` | Parsed tags from `**Tags:**` |
+| `voices_used` | Parsed participants from `**Voices used:**` when present |
+| `related_rounds` | Numeric round references explicitly linked in prior context or explicit metadata |
+| `source_kind` | Usually `round`; allows future compatibility with special records |
+| `derived_from_markdown` | Explicit reminder that the record is not canonical |
+
+---
+
+## 4. Extraction rules
+
+The extractor should prefer explicit headers and only fall back to light
+pattern-matching where the repo already uses stable conventions.
+
+### Required sources
+
+- `round_id`
+  - from filename
+- `title`
+  - from first markdown heading
+- `status`
+  - from `**Status:**`
+- `tags`
+  - from `**Tags:**`
+
+### Recommended structured sources
+
+- `voices_used`
+  - from `**Voices used:**`
+- `related_rounds`
+  - from a future explicit header if added later
+  - otherwise from the `Relevant prior context` section using stable `**Round N**`
+    references
+
+### Non-goals
+
+- no attempt to canonicalize arbitrary prose into opaque inferred structure
+- no LLM-derived semantic tagging in the authoritative index
+- no replacement of markdown with a database-only memory layer
+
+---
+
+## 5. Query surfaces
+
+Tools should query the derived index rather than rescan all round files for
+common retrieval patterns such as:
+
+- all rounds tagged `governance`
+- all rounds related to round `88`
+- all closed rounds touching `structural` and `tooling`
+- round titles and paths for navigation UIs
+
+The index is intentionally optimized for:
+
+- deterministic regeneration
+- diffability in git / `jj`
+- simple JSONL or static-export consumers
+
+---
+
+## 6. Relationship to board resource claims
+
+The round index is a **derived memory/query layer**.
+
+Board resource claims are **operational enforcement state**.
+
+They are related because rounds such as `88` and `89` define the semantics of
+resource contention, but they should not live in the same authority layer:
+
+- markdown explains the policy
+- the round index exposes that policy history for retrieval
+- board tables enforce live claim semantics
+
+---
+
+## 7. Implementation note
+
+When this is implemented, the first extraction pass should support the current
+round corpus without requiring a mass markdown rewrite. Newer rounds can adopt
+more explicit headers over time, but the initial derived index should work from
+today's stable conventions.

--- a/docs/work-items/79-derived-round-index-and-resource-claims.md
+++ b/docs/work-items/79-derived-round-index-and-resource-claims.md
@@ -1,6 +1,6 @@
 # 79 — Derived Round Index and Resource Claim Fields
 
-**Status:** `in-progress` — **Codex**
+**Status:** `done` — **Codex**
 **Tag:** `[structural]`
 
 ## Goal
@@ -43,3 +43,23 @@ board model with explicit resource-claim fields for contention control.
   - `round-73-deliberation-graph-index.md`
   - `round-74-natural-repo-knowledge-base.md`
   - `round-88-agent-resource-contention.md`
+
+## Outcome
+
+- Added [docs/design/ROUND_METADATA_INDEX.md](../design/ROUND_METADATA_INDEX.md)
+  as the derived round metadata extraction spec.
+- Defined a concrete extracted record shape for round metadata, including:
+  - round number
+  - title
+  - tags
+  - status
+  - related rounds
+- Specified the board-side resource-claim fields directly in
+  `BOARD_EXECUTION_MODEL.md`, including:
+  - `contention_class`
+  - `resource_scope`
+  - `exclusive_lease_required`
+- Made the authority split explicit:
+  - markdown is canonical design memory
+  - the round index is a derived query surface
+  - board tables are operational enforcement state

--- a/docs/work-items/79-derived-round-index-and-resource-claims.md
+++ b/docs/work-items/79-derived-round-index-and-resource-claims.md
@@ -1,6 +1,6 @@
 # 79 — Derived Round Index and Resource Claim Fields
 
-**Status:** `ready`
+**Status:** `in-progress` — **Codex**
 **Tag:** `[structural]`
 
 ## Goal
@@ -43,4 +43,3 @@ board model with explicit resource-claim fields for contention control.
   - `round-73-deliberation-graph-index.md`
   - `round-74-natural-repo-knowledge-base.md`
   - `round-88-agent-resource-contention.md`
-

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -194,7 +194,7 @@ The important rule is action class plus resource class:
 
 ### Canonical Markdown + Derived Structure (Round 89)
 
-68. [`79-derived-round-index-and-resource-claims.md`](./79-derived-round-index-and-resource-claims.md) — `ready` — `[structural]` Derived round metadata index and board resource-claim fields
+68. [`79-derived-round-index-and-resource-claims.md`](./79-derived-round-index-and-resource-claims.md) — `in-progress` — **Codex** — `[structural]` Derived round metadata index and board resource-claim fields
 
 ### Sourcegraph Complementarity (Round 90)
 

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -194,7 +194,7 @@ The important rule is action class plus resource class:
 
 ### Canonical Markdown + Derived Structure (Round 89)
 
-68. [`79-derived-round-index-and-resource-claims.md`](./79-derived-round-index-and-resource-claims.md) — `in-progress` — **Codex** — `[structural]` Derived round metadata index and board resource-claim fields
+68. [`79-derived-round-index-and-resource-claims.md`](./79-derived-round-index-and-resource-claims.md) — `done` — **Codex** — `[structural]` Derived round metadata index and board resource-claim fields
 
 ### Sourcegraph Complementarity (Round 90)
 


### PR DESCRIPTION
## Summary\n- add a derived round metadata index spec for canonical markdown round archives\n- define the extracted record shape and recommended JSONL-based artifacts\n- make board-side resource-claim fields explicit in the execution model\n\n## Testing\n- git diff --check\n