### PR TITLE
feat: add sourcegraph thin adapter

### DIFF
--- a/docs/work-items/81-sourcegraph-thin-adapter-implementation.md
+++ b/docs/work-items/81-sourcegraph-thin-adapter-implementation.md
@@ -1,6 +1,6 @@
 # 81 — Sourcegraph Thin Adapter Implementation
 
-**Status:** `in-progress` — **Codex**
+**Status:** `done` — **Codex**
 **Tag:** `[tools]`
 
 ## Goal
@@ -67,3 +67,27 @@ available as an input to subtree-brief generation.
 - Prior round source: `docs/design/rounds/round-90-sourcegraph-deep-search-and-jj-lineage.md`
 - This item is the first implementation slice only; richer brief synthesis and
   outcome linkage can follow separately.
+
+## Outcome
+
+- Added a thin Sourcegraph client in
+  `roundtable/lib/roundtable/sourcegraph/client.ex`.
+- Added a normalized local evidence record in
+  `roundtable/lib/roundtable/sourcegraph/evidence_record.ex`.
+- Added a subtree-brief bridge input helper in
+  `roundtable/lib/roundtable/sourcegraph/subtree_brief_input.ex`.
+- Implemented a bounded retrieval flow keyed by:
+  - `repo`
+  - `revision`
+  - `path_scope`
+- The bounded flow retrieves:
+  - semantic search context
+  - keyword search context
+  - file listing
+  - bounded file reads
+  - commit-oriented history search
+- Added focused tests in `roundtable/test/roundtable/sourcegraph_client_test.exs`
+  covering:
+  - normalized bounded-context evidence generation
+  - standalone file listing and file reads
+  - subtree-brief input generation from normalized evidence

--- a/docs/work-items/81-sourcegraph-thin-adapter-implementation.md
+++ b/docs/work-items/81-sourcegraph-thin-adapter-implementation.md
@@ -1,6 +1,6 @@
 # 81 — Sourcegraph Thin Adapter Implementation
 
-**Status:** `ready`
+**Status:** `in-progress` — **Codex**
 **Tag:** `[tools]`
 
 ## Goal

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -199,4 +199,4 @@ The important rule is action class plus resource class:
 ### Sourcegraph Complementarity (Round 90)
 
 69. [`80-sourcegraph-lineage-integration-briefs.md`](./80-sourcegraph-lineage-integration-briefs.md) — `done` — `[product]` Sourcegraph MCP/API integration for lineage briefs and outcome links
-70. [`81-sourcegraph-thin-adapter-implementation.md`](./81-sourcegraph-thin-adapter-implementation.md) — `in-progress` — **Codex** — `[tools]` First thin Sourcegraph adapter and normalized evidence flow
+70. [`81-sourcegraph-thin-adapter-implementation.md`](./81-sourcegraph-thin-adapter-implementation.md) — `done` — **Codex** — `[tools]` First thin Sourcegraph adapter and normalized evidence flow

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -199,4 +199,4 @@ The important rule is action class plus resource class:
 ### Sourcegraph Complementarity (Round 90)
 
 69. [`80-sourcegraph-lineage-integration-briefs.md`](./80-sourcegraph-lineage-integration-briefs.md) — `done` — `[product]` Sourcegraph MCP/API integration for lineage briefs and outcome links
-70. [`81-sourcegraph-thin-adapter-implementation.md`](./81-sourcegraph-thin-adapter-implementation.md) — `ready` — `[tools]` First thin Sourcegraph adapter and normalized evidence flow
+70. [`81-sourcegraph-thin-adapter-implementation.md`](./81-sourcegraph-thin-adapter-implementation.md) — `in-progress` — **Codex** — `[tools]` First thin Sourcegraph adapter and normalized evidence flow

--- a/roundtable/lib/roundtable/sourcegraph/client.ex
+++ b/roundtable/lib/roundtable/sourcegraph/client.ex
@@ -136,12 +136,15 @@ defmodule Roundtable.Sourcegraph.Client do
       |> Enum.reject(& &1.is_directory)
       |> Enum.take(read_limit)
 
-    Enum.reduce_while(files, {:ok, []}, fn file, {:ok, acc} ->
-      case read_file(repo, revision, file.path, opts) do
-        {:ok, body} -> {:cont, {:ok, acc ++ [body]}}
-        {:error, _reason} = error -> {:halt, error}
-      end
-    end)
+    case Enum.reduce_while(files, [], fn file, acc ->
+           case read_file(repo, revision, file.path, opts) do
+             {:ok, body} -> {:cont, [body | acc]}
+             {:error, _reason} = error -> {:halt, error}
+           end
+         end) do
+      {:error, _reason} = error -> error
+      bodies -> {:ok, Enum.reverse(bodies)}
+    end
   end
 
   defp search(repo, revision, path_scope, query, mode, opts) do
@@ -162,14 +165,11 @@ defmodule Roundtable.Sourcegraph.Client do
     request_fun = Keyword.get(opts, :request_fun, &default_request/1)
 
     case request_fun.(request_options(query, variables, opts)) do
+      {:ok, %{"errors" => errors}} when is_list(errors) and errors != [] ->
+        {:error, {:sourcegraph_errors, errors}}
+
       {:ok, %{"data" => data}} ->
         {:ok, data}
-
-      {:ok, %{"errors" => errors}} ->
-        {:error, {:sourcegraph_errors, errors}}
-
-      {:ok, %{"data" => _data, "errors" => errors}} when is_list(errors) and errors != [] ->
-        {:error, {:sourcegraph_errors, errors}}
 
       {:ok, other} ->
         {:error, {:unexpected_sourcegraph_response, other}}

--- a/roundtable/lib/roundtable/sourcegraph/client.ex
+++ b/roundtable/lib/roundtable/sourcegraph/client.ex
@@ -1,0 +1,354 @@
+defmodule Roundtable.Sourcegraph.Client do
+  @moduledoc """
+  Thin Sourcegraph adapter that retrieves bounded context and normalizes it into
+  local evidence records.
+  """
+
+  alias Roundtable.Sourcegraph.{EvidenceRecord, SubtreeBriefInput}
+
+  @graphql_path "/.api/graphql"
+  @default_result_limit 10
+
+  @type options :: keyword()
+  @type request_fun :: (keyword() -> {:ok, map()} | {:error, term()})
+
+  @spec semantic_search(String.t(), String.t(), String.t(), String.t(), options()) ::
+          {:ok, [map()]} | {:error, term()}
+  def semantic_search(repo, revision, path_scope, query, opts \\ []) do
+    search(repo, revision, path_scope, query, :semantic, opts)
+  end
+
+  @spec keyword_search(String.t(), String.t(), String.t(), String.t(), options()) ::
+          {:ok, [map()]} | {:error, term()}
+  def keyword_search(repo, revision, path_scope, query, opts \\ []) do
+    search(repo, revision, path_scope, query, :keyword, opts)
+  end
+
+  @spec history_search(String.t(), String.t(), String.t(), String.t(), :commit | :diff, options()) ::
+          {:ok, [map()]} | {:error, term()}
+  def history_search(repo, revision, path_scope, query, mode \\ :commit, opts \\ [])
+      when mode in [:commit, :diff] do
+    search(repo, revision, path_scope, query, mode, opts)
+  end
+
+  @spec list_files(String.t(), String.t(), String.t(), options()) :: {:ok, [map()]} | {:error, term()}
+  def list_files(repo, revision, path_scope, opts \\ []) do
+    variables = %{"repo" => repo, "revision" => revision, "path" => path_scope}
+
+    with {:ok, data} <- graphql(list_files_query(), variables, opts) do
+      entries =
+        get_in(data, ["repository", "commit", "tree", "entries"]) || []
+
+      {:ok,
+       Enum.map(entries, fn entry ->
+         %{
+           name: entry["name"],
+           path: entry["path"],
+           is_directory: entry["isDirectory"] || false
+         }
+       end)}
+    end
+  end
+
+  @spec read_file(String.t(), String.t(), String.t(), options()) ::
+          {:ok, %{path: String.t(), content: String.t(), byte_size: non_neg_integer()}} | {:error, term()}
+  def read_file(repo, revision, path, opts \\ []) do
+    variables = %{"repo" => repo, "revision" => revision, "path" => path}
+
+    with {:ok, data} <- graphql(read_file_query(), variables, opts) do
+      case get_in(data, ["repository", "commit", "blob"]) do
+        nil ->
+          {:error, :file_not_found}
+
+        blob ->
+          {:ok,
+           %{
+             path: path,
+             content: blob["content"] || "",
+             byte_size: blob["byteSize"] || 0
+           }}
+      end
+    end
+  end
+
+  @spec bounded_context(String.t(), String.t(), String.t(), String.t(), options()) ::
+          {:ok, %{evidence: EvidenceRecord.t(), brief_input: map()}} | {:error, term()}
+  def bounded_context(repo, revision, path_scope, query, opts \\ []) do
+    created_at = Keyword.get(opts, :created_at, DateTime.utc_now() |> DateTime.to_iso8601())
+    created_by_attempt = Keyword.get(opts, :created_by_attempt)
+    read_limit = Keyword.get(opts, :read_limit, 2)
+
+    with {:ok, semantic_results} <- semantic_search(repo, revision, path_scope, query, opts),
+         {:ok, keyword_results} <- keyword_search(repo, revision, path_scope, query, opts),
+         {:ok, history_results} <- history_search(repo, revision, path_scope, query, :commit, opts),
+         {:ok, file_entries} <- list_files(repo, revision, path_scope, opts),
+         {:ok, file_bodies} <- read_bounded_files(repo, revision, file_entries, read_limit, opts) do
+      files_read =
+        file_bodies
+        |> Enum.map(& &1.path)
+        |> Enum.uniq()
+
+      commits_examined =
+        history_results
+        |> Enum.filter(&(&1.type == "commit"))
+        |> Enum.map(& &1.oid)
+        |> Enum.reject(&is_nil/1)
+        |> Enum.uniq()
+
+      diffs_examined =
+        history_results
+        |> Enum.filter(&(&1.type == "diff"))
+        |> Enum.map(& &1.label)
+        |> Enum.reject(&is_nil/1)
+        |> Enum.uniq()
+
+      evidence =
+        EvidenceRecord.new(%{
+          id: evidence_id(repo, revision, path_scope, query),
+          provider: "sourcegraph",
+          source_type: "sourcegraph_search_context",
+          retrieval_mode: "bounded_context",
+          repo: repo,
+          revision: revision,
+          path_scope: path_scope,
+          sourcegraph_query: query,
+          sourcegraph_conversation_url: Keyword.get(opts, :conversation_url),
+          files_read: files_read,
+          commits_examined: commits_examined,
+          diffs_examined: diffs_examined,
+          created_at: created_at,
+          created_by_attempt: created_by_attempt,
+          summary: summarize_context(path_scope, semantic_results, keyword_results, file_bodies, history_results),
+          search_results: semantic_results ++ keyword_results,
+          history_results: history_results,
+          file_bodies: file_bodies
+        })
+
+      {:ok, %{evidence: evidence, brief_input: SubtreeBriefInput.from_evidence(evidence)}}
+    end
+  end
+
+  defp read_bounded_files(_repo, _revision, [], _read_limit, _opts), do: {:ok, []}
+
+  defp read_bounded_files(repo, revision, file_entries, read_limit, opts) do
+    files =
+      file_entries
+      |> Enum.reject(& &1.is_directory)
+      |> Enum.take(read_limit)
+
+    Enum.reduce_while(files, {:ok, []}, fn file, {:ok, acc} ->
+      case read_file(repo, revision, file.path, opts) do
+        {:ok, body} -> {:cont, {:ok, acc ++ [body]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp search(repo, revision, path_scope, query, mode, opts) do
+    limit = Keyword.get(opts, :result_limit, @default_result_limit)
+    variables = %{"query" => search_query(repo, revision, path_scope, query, mode, limit)}
+
+    with {:ok, data} <- graphql(search_query_document(), variables, opts) do
+      results =
+        get_in(data, ["search", "results", "results"])
+        |> List.wrap()
+        |> Enum.map(&normalize_search_result/1)
+
+      {:ok, results}
+    end
+  end
+
+  defp graphql(query, variables, opts) do
+    request_fun = Keyword.get(opts, :request_fun, &default_request/1)
+
+    case request_fun.(request_options(query, variables, opts)) do
+      {:ok, %{"data" => data}} ->
+        {:ok, data}
+
+      {:ok, %{"errors" => errors}} ->
+        {:error, {:sourcegraph_errors, errors}}
+
+      {:ok, %{"data" => _data, "errors" => errors}} when is_list(errors) and errors != [] ->
+        {:error, {:sourcegraph_errors, errors}}
+
+      {:ok, other} ->
+        {:error, {:unexpected_sourcegraph_response, other}}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp request_options(query, variables, opts) do
+    base_url = Keyword.get(opts, :base_url, "https://sourcegraph.com")
+    token = Keyword.get(opts, :access_token, System.get_env("SOURCEGRAPH_ACCESS_TOKEN"))
+
+    headers =
+      [{"content-type", "application/json"}]
+      |> maybe_add_auth_header(token)
+
+    [
+      method: :post,
+      url: String.trim_trailing(base_url, "/") <> @graphql_path,
+      headers: headers,
+      json: %{query: query, variables: variables}
+    ]
+  end
+
+  defp maybe_add_auth_header(headers, nil), do: headers
+  defp maybe_add_auth_header(headers, ""), do: headers
+  defp maybe_add_auth_header(headers, token), do: [{"authorization", "token " <> token} | headers]
+
+  defp default_request(opts) do
+    case Req.request(opts) do
+      {:ok, response} -> {:ok, response.body}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp search_query(repo, revision, path_scope, query, mode, limit) do
+    mode_prefix =
+      case mode do
+        :semantic -> "type:file patterntype:literal "
+        :keyword -> "type:file patterntype:regexp "
+        :commit -> "type:commit "
+        :diff -> "type:diff "
+      end
+
+    [
+      mode_prefix,
+      "repo:^",
+      repo,
+      "$ rev:",
+      revision,
+      " file:^",
+      path_scope,
+      " count:",
+      Integer.to_string(limit),
+      " ",
+      query
+    ]
+    |> IO.iodata_to_binary()
+  end
+
+  defp normalize_search_result(%{"__typename" => "FileMatch"} = result) do
+    %{
+      type: "file",
+      path: get_in(result, ["file", "path"]),
+      repository: get_in(result, ["repository", "name"]) || get_in(result, ["file", "repository", "name"]),
+      url: result["url"],
+      preview:
+        result["lineMatches"]
+        |> List.wrap()
+        |> Enum.map(& &1["preview"])
+        |> Enum.reject(&is_nil/1)
+        |> Enum.join("\n")
+    }
+  end
+
+  defp normalize_search_result(%{"__typename" => "CommitSearchResult"} = result) do
+    %{
+      type: "commit",
+      oid: get_in(result, ["commit", "oid"]) || result["oid"],
+      label: get_in(result, ["commit", "subject"]) || result["label"],
+      url: result["url"]
+    }
+  end
+
+  defp normalize_search_result(%{"__typename" => "CommitDiffSearchResult"} = result) do
+    %{
+      type: "diff",
+      oid: result["oid"],
+      label: result["label"],
+      url: result["url"]
+    }
+  end
+
+  defp normalize_search_result(result) do
+    %{
+      type: String.downcase(to_string(result["__typename"] || "unknown")),
+      label: result["label"] || result["url"] || inspect(result)
+    }
+  end
+
+  defp evidence_id(repo, revision, path_scope, query) do
+    encoded =
+      [repo, revision, path_scope, query]
+      |> Enum.join("|")
+      |> :erlang.md5()
+      |> Base.encode16(case: :lower)
+
+    "sgctx_" <> encoded
+  end
+
+  defp summarize_context(path_scope, semantic_results, keyword_results, file_bodies, history_results) do
+    file_count = length(file_bodies)
+    search_count = length(semantic_results) + length(keyword_results)
+    history_count = length(history_results)
+
+    "Bounded Sourcegraph context for #{path_scope}: #{search_count} search hits, #{file_count} files read, #{history_count} history results."
+  end
+
+  defp search_query_document do
+    """
+    query Search($query: String!) {
+      search(query: $query, version: V3) {
+        results {
+          results {
+            __typename
+            ... on FileMatch {
+              url
+              repository { name }
+              file { path repository { name } }
+              lineMatches { preview }
+            }
+            ... on CommitSearchResult {
+              url
+              label
+              commit { oid subject }
+            }
+            ... on CommitDiffSearchResult {
+              url
+              label
+              oid
+            }
+          }
+        }
+      }
+    }
+    """
+  end
+
+  defp list_files_query do
+    """
+    query ListFiles($repo: String!, $revision: String!, $path: String!) {
+      repository(name: $repo) {
+        commit(rev: $revision) {
+          tree(path: $path) {
+            entries {
+              name
+              path
+              isDirectory
+            }
+          }
+        }
+      }
+    }
+    """
+  end
+
+  defp read_file_query do
+    """
+    query ReadFile($repo: String!, $revision: String!, $path: String!) {
+      repository(name: $repo) {
+        commit(rev: $revision) {
+          blob(path: $path) {
+            byteSize
+            content
+          }
+        }
+      }
+    }
+    """
+  end
+end

--- a/roundtable/lib/roundtable/sourcegraph/evidence_record.ex
+++ b/roundtable/lib/roundtable/sourcegraph/evidence_record.ex
@@ -1,0 +1,67 @@
+defmodule Roundtable.Sourcegraph.EvidenceRecord do
+  @moduledoc """
+  Normalized local record for bounded Sourcegraph-derived evidence.
+  """
+
+  @enforce_keys [
+    :id,
+    :provider,
+    :source_type,
+    :retrieval_mode,
+    :repo,
+    :revision,
+    :path_scope,
+    :sourcegraph_query,
+    :files_read,
+    :commits_examined,
+    :diffs_examined,
+    :created_at,
+    :summary
+  ]
+  defstruct [
+    :id,
+    :provider,
+    :source_type,
+    :retrieval_mode,
+    :repo,
+    :revision,
+    :path_scope,
+    :sourcegraph_query,
+    :sourcegraph_conversation_url,
+    :files_read,
+    :commits_examined,
+    :diffs_examined,
+    :created_at,
+    :created_by_attempt,
+    :summary,
+    :search_results,
+    :history_results,
+    :file_bodies
+  ]
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          provider: String.t(),
+          source_type: String.t(),
+          retrieval_mode: String.t(),
+          repo: String.t(),
+          revision: String.t(),
+          path_scope: String.t(),
+          sourcegraph_query: String.t(),
+          sourcegraph_conversation_url: String.t() | nil,
+          files_read: [String.t()],
+          commits_examined: [String.t()],
+          diffs_examined: [String.t()],
+          created_at: String.t(),
+          created_by_attempt: String.t() | nil,
+          summary: String.t(),
+          search_results: [map()],
+          history_results: [map()],
+          file_bodies: [%{path: String.t(), content: String.t()}]
+        }
+
+  @spec new(map()) :: t()
+  def new(attrs) do
+    struct!(__MODULE__, attrs)
+  end
+end

--- a/roundtable/lib/roundtable/sourcegraph/subtree_brief_input.ex
+++ b/roundtable/lib/roundtable/sourcegraph/subtree_brief_input.ex
@@ -1,0 +1,30 @@
+defmodule Roundtable.Sourcegraph.SubtreeBriefInput do
+  @moduledoc """
+  Thin bridge that makes normalized Sourcegraph evidence available as bounded
+  input to subtree-brief generation.
+  """
+
+  alias Roundtable.Sourcegraph.EvidenceRecord
+
+  @spec from_evidence(EvidenceRecord.t()) :: map()
+  def from_evidence(%EvidenceRecord{} = evidence) do
+    %{
+      repo: evidence.repo,
+      revision: evidence.revision,
+      path_scope: evidence.path_scope,
+      source_evidence: %{
+        id: evidence.id,
+        provider: evidence.provider,
+        source_type: evidence.source_type,
+        retrieval_mode: evidence.retrieval_mode,
+        query: evidence.sourcegraph_query,
+        conversation_url: evidence.sourcegraph_conversation_url,
+        files_read: evidence.files_read,
+        commits_examined: evidence.commits_examined,
+        diffs_examined: evidence.diffs_examined,
+        summary: evidence.summary
+      },
+      evidence_records: [evidence]
+    }
+  end
+end

--- a/roundtable/test/roundtable/sourcegraph_client_test.exs
+++ b/roundtable/test/roundtable/sourcegraph_client_test.exs
@@ -242,4 +242,19 @@ defmodule Roundtable.Sourcegraph.ClientTest do
     assert get_in(brief_input, [:source_evidence, :summary]) == "Refresh flow context"
     assert brief_input.evidence_records == [evidence]
   end
+
+  test "treats graphql errors as authoritative even when data is present" do
+    request_fun = fn _opts ->
+      {:ok,
+       %{
+         "data" => %{"search" => %{"results" => %{"results" => []}}},
+         "errors" => [%{"message" => "partial failure"}]
+       }}
+    end
+
+    assert {:error, {:sourcegraph_errors, [%{"message" => "partial failure"}]}} =
+             Client.semantic_search("acme/auth-service", "refs/heads/main", "src/auth", "token refresh",
+               request_fun: request_fun
+             )
+  end
 end

--- a/roundtable/test/roundtable/sourcegraph_client_test.exs
+++ b/roundtable/test/roundtable/sourcegraph_client_test.exs
@@ -1,0 +1,245 @@
+defmodule Roundtable.Sourcegraph.ClientTest do
+  use ExUnit.Case, async: true
+
+  alias Roundtable.Sourcegraph.{Client, EvidenceRecord, SubtreeBriefInput}
+
+  test "retrieves bounded context and normalizes it into an evidence record" do
+    parent = self()
+
+    request_fun = fn opts ->
+      send(parent, {:request, opts})
+      query = opts[:json][:query]
+      variables = opts[:json][:variables]
+
+      cond do
+        String.contains?(query, "query Search") and String.contains?(variables["query"], "type:file patterntype:literal") ->
+          {:ok,
+           %{
+             "data" => %{
+               "search" => %{
+                 "results" => %{
+                   "results" => [
+                     %{
+                       "__typename" => "FileMatch",
+                       "url" => "/github.com/acme/auth-service/-/blob/src/auth/refresh.ts",
+                       "repository" => %{"name" => "acme/auth-service"},
+                       "file" => %{"path" => "src/auth/refresh.ts", "repository" => %{"name" => "acme/auth-service"}},
+                       "lineMatches" => [%{"preview" => "refresh flow"}]
+                     }
+                   ]
+                 }
+               }
+             }
+           }}
+
+        String.contains?(query, "query Search") and String.contains?(variables["query"], "type:file patterntype:regexp") ->
+          {:ok,
+           %{
+             "data" => %{
+               "search" => %{
+                 "results" => %{
+                   "results" => [
+                     %{
+                       "__typename" => "FileMatch",
+                       "url" => "/github.com/acme/auth-service/-/blob/src/auth/token_store.ts",
+                       "repository" => %{"name" => "acme/auth-service"},
+                       "file" => %{"path" => "src/auth/token_store.ts", "repository" => %{"name" => "acme/auth-service"}},
+                       "lineMatches" => [%{"preview" => "token store"}]
+                     }
+                   ]
+                 }
+               }
+             }
+           }}
+
+        String.contains?(query, "query Search") and String.contains?(variables["query"], "type:commit") ->
+          {:ok,
+           %{
+             "data" => %{
+               "search" => %{
+                 "results" => %{
+                   "results" => [
+                     %{
+                       "__typename" => "CommitSearchResult",
+                       "url" => "/github.com/acme/auth-service/-/commit/deadbeef",
+                       "label" => "tighten refresh rotation",
+                       "commit" => %{"oid" => "deadbeef", "subject" => "tighten refresh rotation"}
+                     }
+                   ]
+                 }
+               }
+             }
+           }}
+
+        String.contains?(query, "query ListFiles") ->
+          assert variables == %{
+                   "path" => "src/auth",
+                   "repo" => "acme/auth-service",
+                   "revision" => "refs/heads/main"
+                 }
+
+          {:ok,
+           %{
+             "data" => %{
+               "repository" => %{
+                 "commit" => %{
+                   "tree" => %{
+                     "entries" => [
+                       %{"name" => "refresh.ts", "path" => "src/auth/refresh.ts", "isDirectory" => false},
+                       %{"name" => "token_store.ts", "path" => "src/auth/token_store.ts", "isDirectory" => false}
+                     ]
+                   }
+                 }
+               }
+             }
+           }}
+
+        String.contains?(query, "query ReadFile") and variables["path"] == "src/auth/refresh.ts" ->
+          {:ok,
+           %{
+             "data" => %{
+               "repository" => %{
+                 "commit" => %{
+                   "blob" => %{"byteSize" => 27, "content" => "def refresh(), do: :ok\n"}
+                 }
+               }
+             }
+           }}
+
+        String.contains?(query, "query ReadFile") and variables["path"] == "src/auth/token_store.ts" ->
+          {:ok,
+           %{
+             "data" => %{
+               "repository" => %{
+                 "commit" => %{
+                   "blob" => %{"byteSize" => 32, "content" => "def token_store(), do: :ok\n"}
+                 }
+               }
+             }
+           }}
+
+        true ->
+          flunk("unexpected request: #{inspect(opts)}")
+      end
+    end
+
+    assert {:ok, %{evidence: %EvidenceRecord{} = evidence, brief_input: brief_input}} =
+             Client.bounded_context(
+               "acme/auth-service",
+               "refs/heads/main",
+               "src/auth",
+               "token refresh",
+               request_fun: request_fun,
+               created_by_attempt: "att_42",
+               created_at: "2026-05-22T18:00:00Z"
+             )
+
+    assert evidence.provider == "sourcegraph"
+    assert evidence.repo == "acme/auth-service"
+    assert evidence.revision == "refs/heads/main"
+    assert evidence.path_scope == "src/auth"
+    assert evidence.sourcegraph_query == "token refresh"
+    assert evidence.created_by_attempt == "att_42"
+    assert evidence.files_read == ["src/auth/refresh.ts", "src/auth/token_store.ts"]
+    assert evidence.commits_examined == ["deadbeef"]
+    assert evidence.summary =~ "Bounded Sourcegraph context for src/auth"
+    assert length(evidence.search_results) == 2
+    assert length(evidence.history_results) == 1
+    assert brief_input.repo == "acme/auth-service"
+    assert get_in(brief_input, [:source_evidence, :query]) == "token refresh"
+
+    assert_received {:request, req}
+    assert req[:url] =~ "/.api/graphql"
+  end
+
+  test "supports standalone file listing and file reads" do
+    request_fun = fn opts ->
+      query = opts[:json][:query]
+      variables = opts[:json][:variables]
+
+      cond do
+        String.contains?(query, "query ListFiles") ->
+          {:ok,
+           %{
+             "data" => %{
+               "repository" => %{
+                 "commit" => %{
+                   "tree" => %{
+                     "entries" => [
+                       %{"name" => "auth", "path" => "src/auth", "isDirectory" => true},
+                       %{"name" => "refresh.ts", "path" => "src/auth/refresh.ts", "isDirectory" => false}
+                     ]
+                   }
+                 }
+               }
+             }
+           }}
+
+        String.contains?(query, "query ReadFile") ->
+          assert variables["path"] == "src/auth/refresh.ts"
+
+          {:ok,
+           %{
+             "data" => %{
+               "repository" => %{
+                 "commit" => %{
+                   "blob" => %{"byteSize" => 11, "content" => "hello world"}
+                 }
+               }
+             }
+           }}
+
+        true ->
+          flunk("unexpected request: #{inspect(opts)}")
+      end
+    end
+
+    assert {:ok, files} =
+             Client.list_files("acme/auth-service", "refs/heads/main", "src/auth",
+               request_fun: request_fun
+             )
+
+    assert files == [
+             %{name: "auth", path: "src/auth", is_directory: true},
+             %{name: "refresh.ts", path: "src/auth/refresh.ts", is_directory: false}
+           ]
+
+    assert {:ok, file_body} =
+             Client.read_file("acme/auth-service", "refs/heads/main", "src/auth/refresh.ts",
+               request_fun: request_fun
+             )
+
+    assert file_body.content == "hello world"
+  end
+
+  test "builds subtree brief input directly from evidence" do
+    evidence =
+      EvidenceRecord.new(%{
+        id: "sgctx_example",
+        provider: "sourcegraph",
+        source_type: "sourcegraph_search_context",
+        retrieval_mode: "bounded_context",
+        repo: "acme/auth-service",
+        revision: "refs/heads/main",
+        path_scope: "src/auth",
+        sourcegraph_query: "token refresh",
+        sourcegraph_conversation_url: nil,
+        files_read: ["src/auth/refresh.ts"],
+        commits_examined: ["deadbeef"],
+        diffs_examined: [],
+        created_at: "2026-05-22T18:00:00Z",
+        created_by_attempt: "att_42",
+        summary: "Refresh flow context",
+        search_results: [],
+        history_results: [],
+        file_bodies: []
+      })
+
+    brief_input = SubtreeBriefInput.from_evidence(evidence)
+
+    assert brief_input.path_scope == "src/auth"
+    assert get_in(brief_input, [:source_evidence, :files_read]) == ["src/auth/refresh.ts"]
+    assert get_in(brief_input, [:source_evidence, :summary]) == "Refresh flow context"
+    assert brief_input.evidence_records == [evidence]
+  end
+end


### PR DESCRIPTION
## Summary\n- add a thin Sourcegraph client for bounded search, file, and history retrieval\n- normalize retrieved context into a local evidence record\n- expose a subtree-brief input bridge from normalized Sourcegraph evidence\n\n## Testing\n- nix develop . --command bash -lc 'cd roundtable && mix deps.get && mix test test/roundtable/sourcegraph_client_test.exs'\n- git diff --check\n