### PR TITLE
docs: define controlled executor contract

### DIFF
--- a/docs/design/BOARD_EXECUTION_MODEL.md
+++ b/docs/design/BOARD_EXECUTION_MODEL.md
@@ -23,6 +23,9 @@ orchestration tools without reopening the architecture:
 
 This document turns that consensus into a concrete execution model.
 
+For the executor/provider edge that preserves this board authority while
+delegating compute, see `docs/design/CONTROLLED_EXECUTOR_CONTRACT.md`.
+
 ---
 
 ## 2. Boundary of responsibility

--- a/docs/design/CONTROLLED_EXECUTOR_CONTRACT.md
+++ b/docs/design/CONTROLLED_EXECUTOR_CONTRACT.md
@@ -105,14 +105,14 @@ operations.
 | Operation | Purpose |
 |---|---|
 | `accept_job` | Confirm the executor accepted a specific lease-backed job |
-| `start_job` | Report actual execution start |
+| `start_attempt` | Report actual execution start for the canonical attempt |
 | `heartbeat_job` | Renew liveness and carry progress metadata |
-| `append_job_log` | Stream structured log/progress slices |
+| `append_attempt_event` | Stream structured progress, log slices, warnings, or summaries |
 | `append_job_artifact` | Register output bundles, patches, reports, or test logs |
 | `return_attestation` | Return execution attestation/evidence summary |
 | `request_gate` | Ask the control plane for structured human or policy input |
-| `finish_job` | Report terminal success with outputs |
-| `fail_job` | Report terminal failure with machine-usable class |
+| `complete_attempt` | Report terminal success with outputs |
+| `fail_attempt` | Report terminal failure with machine-usable class |
 | `abort_job` | Acknowledge cancellation or lease revocation |
 
 The exact transport can vary. The semantic boundary should not.
@@ -197,7 +197,7 @@ Minimum classes:
 | Failure class | Meaning |
 |---|---|
 | `input_error` | Job envelope invalid or missing required context |
-| `executor_error` | Runner or wrapper failure |
+| `tool_error` | Runner, CLI, wrapper, or subprocess failure |
 | `runtime_disconnect` | Lost worker during execution |
 | `timeout` | Soft/hard timeout exceeded |
 | `policy_denied` | Scope or credential rule prevented action |

--- a/docs/design/CONTROLLED_EXECUTOR_CONTRACT.md
+++ b/docs/design/CONTROLLED_EXECUTOR_CONTRACT.md
@@ -1,0 +1,305 @@
+# Controlled Executor Contract
+
+**Status:** Drafted from Round 121  
+**Purpose:** Define the narrow execution-provider contract that lets the
+control plane keep authority over claims, leases, attempts, and promotion while
+delegating compute to local runners or Buildkite-like external executors.
+
+---
+
+## 1. Boundary
+
+The control plane should remain authoritative for:
+
+- claims
+- leases
+- attempt lineage
+- scoped credentials
+- trust-tier decisions
+- promotion and publish authority
+
+The executor should remain responsible for:
+
+- job launch
+- sandboxed command execution
+- heartbeat / liveness reporting
+- log and artifact return
+- attestation return
+
+This contract exists to keep orchestration authority separate from execution
+runtime.
+
+---
+
+## 2. Why "Buildkite-compatible" matters
+
+The intent is not to clone one provider API exactly.
+
+The intent is to preserve the useful shape of a Buildkite-like worker model:
+
+- the control plane dispatches work
+- executors pull or receive runnable jobs
+- executors do not define promotion meaning
+- job completion returns evidence, not authority
+
+That shape is compatible with:
+
+- local homelab runners
+- workstation-bound daemon executors
+- future hosted execution pools
+- existing CI systems used as controlled workers
+
+---
+
+## 3. Control-plane owned objects
+
+The executor must treat the following as upstream authority, not local state it
+may redefine:
+
+- `Claim`
+- `Lease`
+- `Attempt`
+- `ReviewState`
+- `PromotionGate`
+- `AuthorityScope`
+- `DecisionRecord`
+
+The executor may cache or mirror some of this state for performance, but it
+must not become the only place where that meaning exists.
+
+---
+
+## 4. Required job envelope
+
+Every runnable job issued to an executor should include a bounded envelope.
+
+Minimum fields:
+
+| Field | Meaning |
+|---|---|
+| `job_id` | Stable executor job ID |
+| `attempt_ref` | Canonical attempt ID |
+| `claim_ref` | Canonical claim ID |
+| `lease_ref` | Active execution lease |
+| `workflow_ref` | Optional workflow policy bundle |
+| `repo_ref` | Repo target |
+| `revision_hint` | Branch/ref/commit context to materialize |
+| `task_type` | `code_change`, `review`, `benchmark`, etc. |
+| `input_payload` | Structured task input |
+| `credential_bundle_ref` | Short-lived scoped credential handle |
+| `artifact_policy` | Upload/retention rules |
+| `timeout_policy` | Soft/hard timeout expectations |
+| `attestation_policy` | Required attestation shape |
+| `return_contract` | Expected terminal outputs |
+
+The job envelope is what makes an executor replaceable without moving
+governance meaning into provider YAML.
+
+---
+
+## 5. Required executor operations
+
+The controlled executor contract should expose a small set of semantic
+operations.
+
+| Operation | Purpose |
+|---|---|
+| `accept_job` | Confirm the executor accepted a specific lease-backed job |
+| `start_job` | Report actual execution start |
+| `heartbeat_job` | Renew liveness and carry progress metadata |
+| `append_job_log` | Stream structured log/progress slices |
+| `append_job_artifact` | Register output bundles, patches, reports, or test logs |
+| `return_attestation` | Return execution attestation/evidence summary |
+| `request_gate` | Ask the control plane for structured human or policy input |
+| `finish_job` | Report terminal success with outputs |
+| `fail_job` | Report terminal failure with machine-usable class |
+| `abort_job` | Acknowledge cancellation or lease revocation |
+
+The exact transport can vary. The semantic boundary should not.
+
+---
+
+## 6. Lease and authority semantics
+
+### 6.1 Job execution requires a live lease
+
+Executors must treat `lease_ref` as a hard precondition for mutation work.
+
+If the lease:
+
+- expires
+- is revoked
+- is superseded
+- loses required authority scope
+
+then the executor must stop mutating and report the interruption.
+
+### 6.2 Executors do not mint authority
+
+Executors must not be able to:
+
+- promote a release
+- publish an artifact
+- mark trust-tier transitions as authoritative
+- override a supersession decision
+- approve their own human gate
+
+They may request those actions; they do not own their meaning.
+
+---
+
+## 7. Credential model
+
+The executor should receive short-lived, scope-bounded credentials rather than
+ambient long-lived secrets.
+
+Minimum principles:
+
+- credentials are issued per job or attempt
+- credentials are tied to claim/lease context
+- publish-capable credentials are separate from read/build credentials
+- credentials are revocable when a lease is superseded or cancelled
+
+This allows existing CI providers to execute useful work without inheriting
+full release authority.
+
+---
+
+## 8. Artifact and attestation return
+
+Executors should return evidence, not only a pass/fail bit.
+
+Minimum return classes:
+
+- structured logs
+- patch / diff bundle
+- test and benchmark outputs
+- artifact references
+- execution attestation
+- compact terminal summary
+
+The control plane should decide how that evidence affects:
+
+- trust tier
+- review surface
+- promotion gates
+- publish readiness
+
+---
+
+## 9. Failure model
+
+Executors must return structured failure classes that the control plane can use
+for retry and governance semantics.
+
+Minimum classes:
+
+| Failure class | Meaning |
+|---|---|
+| `input_error` | Job envelope invalid or missing required context |
+| `executor_error` | Runner or wrapper failure |
+| `runtime_disconnect` | Lost worker during execution |
+| `timeout` | Soft/hard timeout exceeded |
+| `policy_denied` | Scope or credential rule prevented action |
+| `lease_revoked` | Live authority was withdrawn |
+| `superseded` | Newer attempt invalidated current run |
+| `unknown_error` | Failure could not be classified |
+
+These are executor reports. The control plane remains responsible for deciding
+whether retry, cancellation, or human review follows.
+
+---
+
+## 10. Human and policy gates
+
+Executors must support a structured pause model rather than open-ended
+interactive drift.
+
+Typical reasons:
+
+- missing clarification
+- risky write boundary
+- promotion boundary reached
+- conflicting branch or artifact state
+- unavailable credential scope
+
+The executor may request a gate and pause. It must not silently keep going past
+a boundary that belongs to a human or the control plane.
+
+---
+
+## 11. Compatibility tiers
+
+The contract should support three practical executor classes.
+
+### 11.1 Local daemon executor
+
+- strongest fit for subscription-backed CLI agents
+- direct lease renewal
+- rich local tool access
+
+### 11.2 Buildkite-like external worker
+
+- remote worker or agent accepts a lease-backed job
+- host control plane still owns claim/attempt/promotion meaning
+- useful for fast adoption in existing CI ecosystems
+
+### 11.3 Future hosted execution provider
+
+- managed pool under the same contract
+- may offer richer telemetry or autoscaling
+- still subordinate to control-plane authority
+
+---
+
+## 12. Graceful degradation
+
+When advanced executor features are absent, the contract should degrade without
+losing governance meaning.
+
+| Missing feature | Required fallback |
+|---|---|
+| live log streaming | upload logs at checkpoints or terminal state |
+| attestation richness | return minimal verifiable completion metadata |
+| interactive gate callback | pause and wait for poll-based resume |
+| artifact push channel | return artifact manifest with retrievable locations |
+
+What must not degrade:
+
+- lease enforcement
+- attempt lineage
+- authority boundaries
+- promotion meaning
+
+---
+
+## 13. Relationship to adjacent contracts
+
+This contract sits between:
+
+- `BOARD_EXECUTION_MODEL.md`
+- `LOCAL_DAEMON_CONTRACT.md`
+- backend/provider integration contracts
+
+The board defines the durable execution state model.
+The daemon contract defines one local runtime implementation path.
+This controlled executor contract defines the portable execution-provider edge
+that lets either a local daemon or a Buildkite-like worker plug in without
+becoming sovereign.
+
+---
+
+## 14. Non-goals
+
+This contract does not attempt to:
+
+- reimplement a generic workflow engine
+- standardize every CI vendor API
+- move publish authority into the executor
+- collapse the control plane into job YAML
+
+Its job is narrower:
+
+- define the first portable executor boundary
+- keep execution providers replaceable
+- preserve control-plane authority above runtime choice

--- a/docs/design/LOCAL_DAEMON_CONTRACT.md
+++ b/docs/design/LOCAL_DAEMON_CONTRACT.md
@@ -22,6 +22,9 @@ opaque server-side jobs pretending all providers are equal APIs.
 
 This contract makes that local-execution model explicit.
 
+For the broader execution-provider boundary that also covers Buildkite-like
+controlled workers, see `docs/design/CONTROLLED_EXECUTOR_CONTRACT.md`.
+
 ---
 
 ## 2. Terms

--- a/docs/work-items/95-buildkite-compatible-controlled-executor.md
+++ b/docs/work-items/95-buildkite-compatible-controlled-executor.md
@@ -1,6 +1,6 @@
 # 95 — Buildkite-Compatible Controlled Executor
 
-**Status:** `ready`
+**Status:** `done` — **Codex**
 **Tag:** `[tools]`
 
 ## Goal
@@ -54,3 +54,16 @@ into GitHub Actions semantics.
   - `75-lightweight-workflow-definitions.md`
   - `89-forge-claim-and-lease-protocol.md`
   - `93-backend-adapter-and-performance-tier-contract.md`
+
+## Outcome
+
+- Added
+  [docs/design/CONTROLLED_EXECUTOR_CONTRACT.md](../design/CONTROLLED_EXECUTOR_CONTRACT.md)
+  as the narrow executor/provider contract note.
+- Defined the bounded job envelope and executor operations required to run
+  lease-backed work without moving claims, attempts, or promotion meaning into
+  the runner.
+- Specified lease, credential, artifact, attestation, failure, and gate
+  semantics for Buildkite-like controlled executors.
+- Kept the control plane authoritative for claims, leases, authority, trust,
+  and promotion while leaving compute and job launch to replaceable workers.

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -69,7 +69,7 @@ The important rule is action class plus resource class:
 94. [`92-canonical-governance-object-model.md`](./92-canonical-governance-object-model.md) — `done` — **Codex** — `[structural]` Canonical governance object model
 95. [`93-backend-adapter-and-performance-tier-contract.md`](./93-backend-adapter-and-performance-tier-contract.md) — `done` — **Codex** — `[hosting]` Backend adapter and performance-tier contract
 96. [`94-governance-state-export-and-backend-migration.md`](./94-governance-state-export-and-backend-migration.md) — `done` — **Codex** — `[integrity]` Governance state export and backend migration
-97. [`95-buildkite-compatible-controlled-executor.md`](./95-buildkite-compatible-controlled-executor.md) — `ready` — `[tools]` Buildkite-compatible controlled executor
+97. [`95-buildkite-compatible-controlled-executor.md`](./95-buildkite-compatible-controlled-executor.md) — `done` — **Codex** — `[tools]` Buildkite-compatible controlled executor
 98. [`96-board-kanban-read-model.md`](./96-board-kanban-read-model.md) — `ready` — `[structural]` Board kanban read model
 99. [`97-browseable-board-surface.md`](./97-browseable-board-surface.md) — `ready` — `[product]` Browseable board surface
 


### PR DESCRIPTION
## Summary
- add a controlled executor contract for Buildkite-like and local execution providers
- keep claims, leases, attempts, credentials, and promotion meaning in the control plane
- mark work item 95 done and cross-link the executor contract from the board and daemon docs

## Testing
- git diff --check