### PR TITLE
feat: add browseable board surface

### DIFF
--- a/docs/work-items/97-browseable-board-surface.md
+++ b/docs/work-items/97-browseable-board-surface.md
@@ -1,6 +1,6 @@
 # 97 — Browseable Board Surface
 
-**Status:** `ready`
+**Status:** `done` — **Codex**
 **Tag:** `[product]`
 
 ## Goal
@@ -51,3 +51,17 @@ complete.
   - `57-agent-task-queue.md`
   - `73-board-work-item-schema.md`
   - `96-board-kanban-read-model.md`
+
+## Outcome
+
+- Added a real browse-first `/board` LiveView using the existing Phoenix web
+  surface instead of creating a separate dashboard.
+- Implemented
+  [Roundtable.BoardKanbanReadModel](../../roundtable/lib/roundtable/board_kanban_read_model.ex)
+  to derive current lanes, card summaries, alerts, and detail state from
+  canonical board tables.
+- Added card drill-down, read-only filters, runtime/gate visibility, and recent
+  attempt-event summaries so operators can browse board state without reading
+  raw rows or logs.
+- Linked the landing page to the new board surface and added focused tests for
+  both the read model and the LiveView.

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -71,7 +71,7 @@ The important rule is action class plus resource class:
 96. [`94-governance-state-export-and-backend-migration.md`](./94-governance-state-export-and-backend-migration.md) — `done` — **Codex** — `[integrity]` Governance state export and backend migration
 97. [`95-buildkite-compatible-controlled-executor.md`](./95-buildkite-compatible-controlled-executor.md) — `done` — **Codex** — `[tools]` Buildkite-compatible controlled executor
 98. [`96-board-kanban-read-model.md`](./96-board-kanban-read-model.md) — `done` — **Codex** — `[structural]` Board kanban read model
-99. [`97-browseable-board-surface.md`](./97-browseable-board-surface.md) — `ready` — `[product]` Browseable board surface
+99. [`97-browseable-board-surface.md`](./97-browseable-board-surface.md) — `done` — **Codex** — `[product]` Browseable board surface
 
 ### Foundation (do first, in order)
 

--- a/roundtable/lib/roundtable/board_kanban_read_model.ex
+++ b/roundtable/lib/roundtable/board_kanban_read_model.ex
@@ -1,0 +1,329 @@
+defmodule Roundtable.BoardKanbanReadModel do
+  @moduledoc """
+  Browse-first kanban projection over canonical board tables.
+
+  This module derives current lane placement, card summaries, and recent
+  attempt context without mutating or collapsing the underlying board lineage.
+  """
+
+  alias Roundtable.Board
+
+  @queued_statuses ~w(queued retry_scheduled resumable)
+  @active_statuses ~w(claimed running)
+  @healthy_terminal_exit_classes ~w(success cancelled)
+  @lane_order ~w(gated attention running queued closed_with_issue done)
+
+  @spec snapshot(String.t() | nil, keyword()) :: {:ok, map()} | {:error, term()}
+  def snapshot(repo_path, opts \\ []) do
+    board = Keyword.get(opts, :board, Board)
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+
+    with {:ok, items} <- board.list_work_items(repo_path, board_opts(opts)),
+         {:ok, runtimes} <- board.list_runtime_heartbeats(repo_path, board_opts(opts)) do
+      runtime_index = Map.new(runtimes, &{&1.runtime_id, &1})
+
+      cards =
+        items
+        |> Enum.map(&build_card(&1, repo_path, board, runtime_index, now, opts))
+        |> Enum.sort_by(&{lane_rank(&1.lane), &1.priority, &1.updated_at || "", &1.work_item_id})
+
+      {:ok,
+       %{
+         repo_path: repo_path,
+         generated_at: DateTime.to_iso8601(now),
+         lanes: build_lanes(cards),
+         cards: cards,
+         filters: build_filters(cards),
+         counts: lane_counts(cards)
+       }}
+    end
+  end
+
+  defp build_card(item, repo_path, board, runtime_index, now, opts) do
+    {:ok, attempts} = board.list_attempts(repo_path, item.id, board_opts(opts))
+    {:ok, gates} = board.list_human_gates(repo_path, item.id, board_opts(opts))
+
+    current_attempt = current_attempt(attempts)
+    runtime = runtime_for_attempt(current_attempt, runtime_index)
+    open_gate = Enum.find(gates, &(&1.state == "open"))
+    gate_state = derive_gate_state(gates)
+    {events, recent_event} = current_attempt_events(repo_path, current_attempt, board, opts)
+    lease_state = derive_lease_state(item, current_attempt, now)
+    runtime_status = derive_runtime_status(runtime)
+    status_conflict? = status_conflict?(item, current_attempt)
+    superseded? = superseded_attempt?(current_attempt)
+
+    alert_refs =
+      []
+      |> maybe_add_alert(open_gate && "open_human_gate")
+      |> maybe_add_alert(lease_state in ["stale", "expired", "missing"] && "stale_lease")
+      |> maybe_add_alert(runtime_status == "offline" && "runtime_offline")
+      |> maybe_add_alert(runtime_status == "degraded" && "runtime_degraded")
+      |> maybe_add_alert(status_conflict? && "status_conflict")
+      |> maybe_add_alert(superseded? && "attempt_superseded")
+      |> maybe_add_alert(
+        current_attempt && current_attempt.exit_class not in [nil | @healthy_terminal_exit_classes] &&
+          current_attempt.status in ["failed", "superseded"] && "terminal_failure"
+      )
+
+    lane = derive_lane(item, current_attempt, open_gate, lease_state, runtime_status, alert_refs)
+
+    %{
+      work_item_id: item.id,
+      lane: lane,
+      title: item.title,
+      repo_ref: item.repo_ref,
+      branch_ref: item.branch_ref,
+      task_type: item.task_type,
+      priority: item.priority,
+      status: item.status,
+      current_attempt_ref: current_attempt && current_attempt.id,
+      attempt_number: current_attempt && current_attempt.attempt_number,
+      attempt_status: current_attempt && current_attempt.status,
+      runtime_ref: runtime && runtime.runtime_id,
+      runtime_status: runtime_status,
+      open_gate_ref: open_gate && open_gate.id,
+      gate_type: open_gate && open_gate.gate_type,
+      gate_state: gate_state,
+      lease_state: lease_state,
+      superseded_by_attempt_ref: nil,
+      summary: derive_summary(item, current_attempt, open_gate, runtime, recent_event, alert_refs),
+      badge_refs:
+        build_badges(item, current_attempt, runtime_status, gate_state, lease_state, alert_refs),
+      alert_refs: alert_refs,
+      updated_at: freshness_timestamp(item, current_attempt, open_gate, runtime, recent_event),
+      recent_events: Enum.take(Enum.reverse(events), 5),
+      attempts: attempts,
+      gates: gates,
+      runtime: runtime
+    }
+  end
+
+  defp board_opts(opts), do: Keyword.drop(opts, [:board, :now])
+
+  defp current_attempt([]), do: nil
+
+  defp current_attempt(attempts) do
+    attempts
+    |> Enum.sort_by(fn attempt ->
+      {attempt.attempt_number || 0, attempt.started_at || "", attempt.id || ""}
+    end, :desc)
+    |> List.first()
+  end
+
+  defp runtime_for_attempt(nil, _runtime_index), do: nil
+  defp runtime_for_attempt(attempt, runtime_index), do: Map.get(runtime_index, attempt.runtime_id)
+
+  defp current_attempt_events(_repo_path, nil, _board, _opts), do: {[], nil}
+
+  defp current_attempt_events(repo_path, attempt, board, opts) do
+    case board.list_attempt_events(repo_path, attempt.id, board_opts(opts)) do
+      {:ok, events} -> {events, List.last(events)}
+      {:error, _} -> {[], nil}
+    end
+  end
+
+  defp derive_gate_state([]), do: "none"
+
+  defp derive_gate_state(gates) do
+    cond do
+      Enum.any?(gates, &(&1.state == "open")) -> "open"
+      Enum.any?(gates, &(&1.state == "resolved")) -> "resolved"
+      true -> "closed"
+    end
+  end
+
+  defp derive_lease_state(item, attempt, now) do
+    cond do
+      is_nil(attempt) ->
+        if item.status in @queued_statuses, do: "not_required", else: "missing"
+
+      attempt.status not in @active_statuses ->
+        "not_required"
+
+      is_nil(attempt.lease_expires_at) ->
+        "missing"
+
+      true ->
+        case parse_datetime(attempt.lease_expires_at) do
+          nil ->
+            "missing"
+
+          expires_at ->
+            diff = DateTime.diff(expires_at, now, :second)
+
+            cond do
+              diff < 0 -> "expired"
+              diff <= 60 -> "stale"
+              true -> "healthy"
+            end
+        end
+    end
+  end
+
+  defp derive_runtime_status(nil), do: "unknown"
+  defp derive_runtime_status(runtime), do: runtime.status || "unknown"
+
+  defp status_conflict?(item, attempt) do
+    case attempt do
+      nil -> false
+      %{status: attempt_status} -> item.status in @queued_statuses and attempt_status in @active_statuses
+    end
+  end
+
+  defp superseded_attempt?(nil), do: false
+  defp superseded_attempt?(attempt), do: attempt.status == "superseded"
+
+  defp derive_lane(item, attempt, open_gate, lease_state, runtime_status, alert_refs) do
+    cond do
+      open_gate ->
+        "gated"
+
+      attention?(attempt, lease_state, runtime_status, alert_refs) ->
+        "attention"
+
+      active?(item, attempt) ->
+        "running"
+
+      item.status in @queued_statuses ->
+        "queued"
+
+      terminal_issue?(item, attempt) ->
+        "closed_with_issue"
+
+      true ->
+        "done"
+    end
+  end
+
+  defp attention?(attempt, lease_state, runtime_status, alert_refs) do
+    attempt && attempt.status in @active_statuses &&
+      (lease_state in ["stale", "expired", "missing"] ||
+         runtime_status in ["offline", "degraded"] ||
+         alert_refs != [])
+  end
+
+  defp active?(item, attempt) do
+    item.status in @active_statuses || (attempt && attempt.status in @active_statuses)
+  end
+
+  defp terminal_issue?(item, attempt) do
+    item.status == "failed" ||
+      (attempt &&
+         (attempt.status == "failed" ||
+            attempt.exit_class not in [nil | @healthy_terminal_exit_classes]))
+  end
+
+  defp derive_summary(item, attempt, open_gate, runtime, recent_event, alert_refs) do
+    cond do
+      open_gate ->
+        "Awaiting #{open_gate.gate_type} gate"
+
+      "stale_lease" in alert_refs ->
+        "Attempt lease needs attention"
+
+      "runtime_offline" in alert_refs ->
+        "Owning runtime is offline"
+
+      recent_event && recent_event.summary not in [nil, ""] ->
+        recent_event.summary
+
+      attempt && attempt.summary not in [nil, ""] ->
+        attempt.summary
+
+      runtime ->
+        "Owned by #{runtime.host_label || runtime.runtime_id}"
+
+      true ->
+        item.title
+    end
+  end
+
+  defp build_badges(item, attempt, runtime_status, gate_state, lease_state, alert_refs) do
+    []
+    |> add_badge("priority:high", item.priority && item.priority <= 25)
+    |> add_badge("task:#{item.task_type}", item.task_type)
+    |> add_badge("runtime:#{runtime_status}", runtime_status not in [nil, "unknown"])
+    |> add_badge("gate:#{gate_state}", gate_state != "none")
+    |> add_badge("lease:#{lease_state}", lease_state not in ["not_required", nil])
+    |> add_badge("attempt:superseded", attempt && attempt.status == "superseded")
+    |> add_badge("retry:scheduled", item.status == "retry_scheduled")
+    |> add_badge("result:failed", terminal_issue?(item, attempt))
+    |> add_badge("result:succeeded", item.status == "succeeded")
+    |> Enum.uniq()
+    |> Enum.reject(&is_nil/1)
+    |> Kernel.++(Enum.map(alert_refs, &"alert:#{&1}"))
+  end
+
+  defp freshness_timestamp(item, attempt, gate, runtime, recent_event) do
+    [
+      item.updated_at,
+      attempt && Map.get(attempt, :finished_at),
+      attempt && Map.get(attempt, :started_at),
+      gate && gate.created_at,
+      runtime && runtime.last_seen_at,
+      recent_event && recent_event.created_at
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.max(fn -> item.updated_at || item.created_at end)
+  end
+
+  defp add_badge(list, _badge, false), do: list
+  defp add_badge(list, _badge, nil), do: list
+  defp add_badge(list, badge, _truthy), do: [badge | list]
+
+  defp maybe_add_alert(list, false), do: list
+  defp maybe_add_alert(list, nil), do: list
+  defp maybe_add_alert(list, alert), do: [alert | list]
+
+  defp build_lanes(cards) do
+    @lane_order
+    |> Enum.map(fn lane ->
+      %{
+        id: lane,
+        title: lane_title(lane),
+        cards: Enum.filter(cards, &(&1.lane == lane))
+      }
+    end)
+  end
+
+  defp build_filters(cards) do
+    %{
+      repos: cards |> Enum.map(& &1.repo_ref) |> Enum.reject(&is_nil/1) |> Enum.uniq() |> Enum.sort(),
+      statuses: cards |> Enum.map(& &1.status) |> Enum.reject(&is_nil/1) |> Enum.uniq() |> Enum.sort(),
+      runtimes:
+        cards |> Enum.map(& &1.runtime_ref) |> Enum.reject(&is_nil/1) |> Enum.uniq() |> Enum.sort(),
+      gates:
+        cards
+        |> Enum.map(& &1.gate_state)
+        |> Enum.reject(&(&1 in [nil, "none"]))
+        |> Enum.uniq()
+        |> Enum.sort()
+    }
+  end
+
+  defp lane_counts(cards) do
+    Enum.reduce(@lane_order, %{}, fn lane, acc ->
+      Map.put(acc, lane, Enum.count(cards, &(&1.lane == lane)))
+    end)
+  end
+
+  defp lane_rank(lane), do: Enum.find_index(@lane_order, &(&1 == lane)) || length(@lane_order)
+
+  defp lane_title("queued"), do: "Queued"
+  defp lane_title("running"), do: "Running"
+  defp lane_title("gated"), do: "Gated"
+  defp lane_title("attention"), do: "Attention"
+  defp lane_title("done"), do: "Done"
+  defp lane_title("closed_with_issue"), do: "Closed With Issue"
+  defp lane_title(other), do: other
+
+  defp parse_datetime(nil), do: nil
+
+  defp parse_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} -> dt
+      _ -> nil
+    end
+  end
+end

--- a/roundtable/lib/roundtable_web/live/board_live.ex
+++ b/roundtable/lib/roundtable_web/live/board_live.ex
@@ -1,0 +1,365 @@
+defmodule RoundtableWeb.BoardLive do
+  @moduledoc """
+  Browse-first board surface backed by the kanban read model.
+  """
+
+  use Phoenix.LiveView
+
+  alias Roundtable.BoardKanbanReadModel
+
+  @impl true
+  def mount(params, _session, socket) do
+    {:ok, load_board(socket, normalize_params(params))}
+  end
+
+  defp load_board(socket, params) do
+    repo_path = board_repo_path()
+    board_module = board_module()
+
+    socket =
+      socket
+      |> assign(:params, params)
+      |> assign(:repo_path, repo_path)
+      |> assign(:filters, %{})
+      |> assign(:counts, %{})
+      |> assign(:selected_card, nil)
+      |> assign(:lanes, [])
+      |> assign(:cards, [])
+      |> assign(:error, nil)
+
+    case BoardKanbanReadModel.snapshot(repo_path, board: board_module) do
+      {:ok, snapshot} ->
+        cards = filter_cards(snapshot.cards, params)
+        selected_card = find_selected_card(cards, params)
+
+        socket
+        |> assign(:snapshot_generated_at, snapshot.generated_at)
+        |> assign(:filters, snapshot.filters)
+        |> assign(:counts, snapshot.counts)
+        |> assign(:cards, cards)
+        |> assign(:lanes, filter_lanes(snapshot.lanes, cards))
+        |> assign(:selected_card, selected_card)
+
+      {:error, :no_local_repo} ->
+        assign(socket, :error, "No local board repo is configured. Set ROUNDTABLE_BOARD_REPO_PATH or ROUNDTABLE_LOCAL_PATH.")
+
+      {:error, reason} ->
+        assign(socket, :error, "Failed to load board state: #{inspect(reason)}")
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div style="max-width: 1320px; margin: 0 auto; padding: 2rem 1rem 4rem;">
+      <header style="display: grid; grid-template-columns: minmax(0, 1.8fr) minmax(320px, 1fr); gap: 1rem; align-items: start; margin-bottom: 1.5rem;">
+        <div>
+          <div style="display: inline-flex; align-items: center; gap: 0.45rem; border: 1px solid #30363d; border-radius: 999px; padding: 0.35rem 0.75rem; color: #58a6ff; font-size: 0.76rem; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.85rem;">
+            Browse-first board
+          </div>
+          <h1 style="font-size: clamp(2rem, 4vw, 3rem); line-height: 1.04; color: #f0f6fc; margin-bottom: 0.55rem;">
+            Vaglio Board
+          </h1>
+          <p style="color: #8b949e; line-height: 1.6; max-width: 54rem; margin-bottom: 1rem;">
+            This surface renders the derived kanban view over canonical board state. Lanes and badges are convenience projections; the underlying attempts, gates, and runtime heartbeats remain authoritative.
+          </p>
+          <div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
+            <a href="/" style={cta_style(:secondary)}>Landing</a>
+            <a href="/forgejo-shell" style={cta_style(:secondary)}>Forgejo Shell</a>
+            <span :if={@repo_path not in [nil, ""]} style="display: inline-flex; align-items: center; border: 1px solid #30363d; border-radius: 999px; padding: 0.72rem 1rem; color: #8b949e; font-size: 0.82rem;">
+              Repo: {@repo_path}
+            </span>
+          </div>
+        </div>
+
+        <div style="background: linear-gradient(180deg, rgba(22,27,34,0.96), rgba(13,17,23,0.96)); border: 1px solid #30363d; border-radius: 16px; padding: 1rem;">
+          <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase; margin-bottom: 0.5rem;">Operator questions</div>
+          <ul style="margin: 0; padding-left: 1rem; color: #8b949e; line-height: 1.6;">
+            <li>What is running right now?</li>
+            <li>What needs a human or operator decision?</li>
+            <li>What looks stale or unsafe?</li>
+            <li>Which runtime owns the latest attempt?</li>
+          </ul>
+        </div>
+      </header>
+
+      <.error_banner :if={@error} msg={@error} />
+
+      <section :if={!@error} style="margin-bottom: 1.25rem;">
+        <div style="display: grid; gap: 0.75rem;">
+          <div style="display: flex; gap: 0.55rem; flex-wrap: wrap;">
+            <.filter_group
+              label="Repo"
+              param="repo"
+              current={Map.get(@params, "repo")}
+              values={@filters.repos}
+              params={@params}
+            />
+            <.filter_group
+              label="Status"
+              param="status"
+              current={Map.get(@params, "status")}
+              values={@filters.statuses}
+              params={@params}
+            />
+            <.filter_group
+              label="Runtime"
+              param="runtime"
+              current={Map.get(@params, "runtime")}
+              values={@filters.runtimes}
+              params={@params}
+            />
+            <.filter_group
+              label="Gate"
+              param="gate"
+              current={Map.get(@params, "gate")}
+              values={@filters.gates}
+              params={@params}
+            />
+          </div>
+
+          <div style="display: flex; gap: 0.65rem; flex-wrap: wrap; align-items: center;">
+            <.count_chip :for={{lane, count} <- @counts} lane={lane} count={count} />
+            <span :if={@snapshot_generated_at} style="color: #8b949e; font-size: 0.8rem; margin-left: auto;">
+              Snapshot {@snapshot_generated_at}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section :if={!@error} style="display: grid; grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr); gap: 1rem; align-items: start;">
+        <div style="display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.85rem; align-items: start;">
+          <div :for={lane <- @lanes} style="background: #0d1117; border: 1px solid #30363d; border-radius: 14px; padding: 0.85rem; min-height: 18rem;">
+            <div style="display: flex; justify-content: space-between; gap: 0.75rem; align-items: baseline; margin-bottom: 0.75rem;">
+              <h2 style="margin: 0; color: #f0f6fc; font-size: 0.95rem;">{lane.title}</h2>
+              <span style="color: #8b949e; font-size: 0.82rem;">{length(lane.cards)}</span>
+            </div>
+
+            <div style="display: grid; gap: 0.65rem;">
+              <a
+                :for={card <- lane.cards}
+                href={board_path(@params, %{"work_item_id" => card.work_item_id})}
+                style={card_style(@selected_card && @selected_card.work_item_id == card.work_item_id, card.lane)}
+              >
+                <div style="display: flex; justify-content: space-between; gap: 0.75rem; margin-bottom: 0.35rem;">
+                  <div style="color: #f0f6fc; font-weight: 600; line-height: 1.35;">{card.title}</div>
+                  <div style="color: #8b949e; font-size: 0.78rem; white-space: nowrap;">{card.work_item_id}</div>
+                </div>
+                <div style="color: #58a6ff; font-size: 0.78rem; margin-bottom: 0.35rem;">{card.repo_ref}</div>
+                <div style="color: #8b949e; font-size: 0.83rem; line-height: 1.45; margin-bottom: 0.55rem;">{card.summary}</div>
+                <div style="display: flex; gap: 0.35rem; flex-wrap: wrap;">
+                  <span :for={badge <- Enum.take(card.badge_refs, 4)} style={badge_style(badge)}>{badge}</span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <aside style="background: linear-gradient(180deg, rgba(22,27,34,0.96), rgba(13,17,23,0.96)); border: 1px solid #30363d; border-radius: 14px; padding: 1rem; position: sticky; top: 1rem;">
+          <%= if @selected_card do %>
+            <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase; margin-bottom: 0.45rem;">Selected card</div>
+            <h2 style="margin: 0 0 0.35rem; color: #f0f6fc; font-size: 1.05rem;">{@selected_card.title}</h2>
+            <div style="color: #8b949e; font-size: 0.82rem; margin-bottom: 0.75rem;">
+              {@selected_card.work_item_id} · {@selected_card.repo_ref}
+            </div>
+
+            <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.55rem; margin-bottom: 0.9rem;">
+              <.detail_metric label="Lane" value={@selected_card.lane} />
+              <.detail_metric label="Status" value={@selected_card.status} />
+              <.detail_metric label="Runtime" value={@selected_card.runtime_ref || "unassigned"} />
+              <.detail_metric label="Lease" value={@selected_card.lease_state} />
+              <.detail_metric label="Gate" value={@selected_card.gate_type || @selected_card.gate_state} />
+              <.detail_metric label="Attempt" value={detail_attempt(@selected_card)} />
+            </div>
+
+            <div style="margin-bottom: 0.9rem;">
+              <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase; margin-bottom: 0.4rem;">Alerts</div>
+              <div style="display: flex; gap: 0.4rem; flex-wrap: wrap;">
+                <span :for={alert <- @selected_card.alert_refs} style="background: rgba(248,81,73,0.12); border: 1px solid rgba(248,81,73,0.3); color: #ff7b72; border-radius: 999px; padding: 0.25rem 0.55rem; font-size: 0.76rem;">
+                  {alert}
+                </span>
+                <span :if={@selected_card.alert_refs == []} style="color: #8b949e; font-size: 0.84rem;">No active alerts</span>
+              </div>
+            </div>
+
+            <div style="margin-bottom: 0.9rem;">
+              <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase; margin-bottom: 0.4rem;">Recent events</div>
+              <div style="display: grid; gap: 0.45rem;">
+                <div :for={event <- @selected_card.recent_events} style="background: rgba(13,17,23,0.86); border: 1px solid #30363d; border-radius: 10px; padding: 0.65rem;">
+                  <div style="display: flex; justify-content: space-between; gap: 0.75rem; margin-bottom: 0.2rem;">
+                    <span style="color: #f0f6fc; font-weight: 600; font-size: 0.84rem;">{event.event_type}</span>
+                    <span style="color: #8b949e; font-size: 0.76rem;">{event.created_at}</span>
+                  </div>
+                  <div style="color: #8b949e; font-size: 0.82rem; line-height: 1.4;">{event.summary || "No summary"}</div>
+                </div>
+                <span :if={@selected_card.recent_events == []} style="color: #8b949e; font-size: 0.84rem;">No recent attempt events</span>
+              </div>
+            </div>
+
+            <div>
+              <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase; margin-bottom: 0.4rem;">Lineage</div>
+              <div style="display: grid; gap: 0.45rem;">
+                <div :for={attempt <- Enum.reverse(@selected_card.attempts)} style="background: rgba(13,17,23,0.86); border: 1px solid #30363d; border-radius: 10px; padding: 0.65rem;">
+                  <div style="display: flex; justify-content: space-between; gap: 0.75rem; margin-bottom: 0.2rem;">
+                    <span style="color: #f0f6fc; font-weight: 600; font-size: 0.84rem;">Attempt #{attempt.attempt_number}</span>
+                    <span style="color: #8b949e; font-size: 0.76rem;">{attempt.status}</span>
+                  </div>
+                  <div style="color: #8b949e; font-size: 0.82rem; line-height: 1.4;">
+                    {attempt.summary || "No summary"}<%= if attempt.exit_class, do: " · #{attempt.exit_class}" %>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% else %>
+            <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase; margin-bottom: 0.45rem;">Card detail</div>
+            <h2 style="margin: 0 0 0.55rem; color: #f0f6fc; font-size: 1.05rem;">Select a work item</h2>
+            <p style="margin: 0; color: #8b949e; line-height: 1.55;">
+              Pick any card to inspect its latest attempt, runtime ownership, gate state, and recent execution history without digging through raw board rows.
+            </p>
+          <% end %>
+        </aside>
+      </section>
+    </div>
+    """
+  end
+
+  attr :msg, :string, required: true
+  defp error_banner(assigns) do
+    ~H"""
+    <div style="background: rgba(248,81,73,0.12); border: 1px solid rgba(248,81,73,0.3); border-radius: 12px; padding: 0.95rem 1rem; color: #ff7b72; margin-bottom: 1rem;">
+      {@msg}
+    </div>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :param, :string, required: true
+  attr :current, :string, default: nil
+  attr :values, :list, default: []
+  attr :params, :map, required: true
+  defp filter_group(assigns) do
+    ~H"""
+    <div style="display: flex; gap: 0.35rem; flex-wrap: wrap; align-items: center;">
+      <span style="color: #8b949e; font-size: 0.8rem;">{@label}</span>
+      <a href={board_path(@params, Map.delete(@params, @param))} style={filter_style(is_nil(@current) || @current == "")}>all</a>
+      <a :for={value <- @values} href={board_path(@params, %{@param => value})} style={filter_style(@current == value)}>{value}</a>
+    </div>
+    """
+  end
+
+  attr :lane, :string, required: true
+  attr :count, :integer, required: true
+  defp count_chip(assigns) do
+    ~H"""
+    <span style="display: inline-flex; align-items: center; gap: 0.35rem; background: #161b22; border: 1px solid #30363d; border-radius: 999px; padding: 0.32rem 0.65rem; color: #c9d1d9; font-size: 0.8rem;">
+      {assigns.lane} <strong style="color: #f0f6fc;">{@count}</strong>
+    </span>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :string, required: true
+  defp detail_metric(assigns) do
+    ~H"""
+    <div style="background: rgba(13,17,23,0.86); border: 1px solid #30363d; border-radius: 10px; padding: 0.65rem;">
+      <div style="color: #58a6ff; font-size: 0.75rem; text-transform: uppercase; margin-bottom: 0.2rem;">{@label}</div>
+      <div style="color: #f0f6fc; font-size: 0.88rem; line-height: 1.35;">{@value}</div>
+    </div>
+    """
+  end
+
+  defp board_module do
+    Application.get_env(:roundtable, :board_module, Roundtable.Board)
+  end
+
+  defp normalize_params(params) when is_map(params), do: params
+  defp normalize_params(_params), do: %{}
+
+  defp board_repo_path do
+    Application.get_env(:roundtable, :board_repo_path) ||
+      System.get_env("ROUNDTABLE_BOARD_REPO_PATH") ||
+      System.get_env("ROUNDTABLE_LOCAL_PATH")
+  end
+
+  defp filter_cards(cards, params) do
+    Enum.filter(cards, fn card ->
+      matches?(card.repo_ref, params["repo"]) and
+        matches?(card.status, params["status"]) and
+        matches?(card.runtime_ref, params["runtime"]) and
+        matches?(card.gate_state, params["gate"])
+    end)
+  end
+
+  defp matches?(_value, nil), do: true
+  defp matches?(_value, ""), do: true
+  defp matches?(value, filter), do: value == filter
+
+  defp filter_lanes(lanes, cards) do
+    ids = MapSet.new(Enum.map(cards, & &1.work_item_id))
+
+    Enum.map(lanes, fn lane ->
+      %{lane | cards: Enum.filter(lane.cards, &MapSet.member?(ids, &1.work_item_id))}
+    end)
+  end
+
+  defp find_selected_card(cards, %{"work_item_id" => work_item_id}) do
+    Enum.find(cards, &(&1.work_item_id == work_item_id))
+  end
+
+  defp find_selected_card(cards, _params), do: List.first(cards)
+
+  defp board_path(params, overrides) do
+    merged =
+      params
+      |> Map.merge(overrides)
+      |> Enum.reject(fn {_k, v} -> v in [nil, ""] end)
+      |> Enum.into(%{})
+
+    query = URI.encode_query(merged)
+    if query == "", do: "/board", else: "/board?#{query}"
+  end
+
+  defp detail_attempt(card) do
+    case {card.current_attempt_ref, card.attempt_number} do
+      {nil, _} -> "none"
+      {_, nil} -> card.current_attempt_ref
+      {_, n} -> "##{n}"
+    end
+  end
+
+  defp cta_style(:secondary) do
+    "display: inline-flex; align-items: center; justify-content: center; text-decoration: none; background: transparent; color: #c9d1d9; border-radius: 999px; padding: 0.72rem 1rem; font-weight: 600; border: 1px solid #30363d;"
+  end
+
+  defp filter_style(true) do
+    "display: inline-flex; align-items: center; text-decoration: none; background: #1f6feb; color: #f0f6fc; border-radius: 999px; padding: 0.25rem 0.55rem; font-size: 0.78rem; border: 1px solid #1f6feb;"
+  end
+
+  defp filter_style(false) do
+    "display: inline-flex; align-items: center; text-decoration: none; background: #161b22; color: #8b949e; border-radius: 999px; padding: 0.25rem 0.55rem; font-size: 0.78rem; border: 1px solid #30363d;"
+  end
+
+  defp card_style(true, lane) do
+    base_card_style(lane) <> " box-shadow: 0 0 0 1px rgba(88,166,255,0.6);"
+  end
+
+  defp card_style(false, lane), do: base_card_style(lane)
+
+  defp base_card_style(lane) do
+    accent =
+      case lane do
+        "gated" -> "#d29922"
+        "attention" -> "#ff7b72"
+        "running" -> "#3fb950"
+        "queued" -> "#58a6ff"
+        "closed_with_issue" -> "#f85149"
+        _ -> "#30363d"
+      end
+
+    "display: block; text-decoration: none; background: linear-gradient(180deg, rgba(22,27,34,0.96), rgba(13,17,23,0.96)); border: 1px solid #{accent}; border-radius: 12px; padding: 0.8rem;"
+  end
+
+  defp badge_style(_badge) do
+    "display: inline-flex; align-items: center; background: rgba(88,166,255,0.1); border: 1px solid rgba(88,166,255,0.22); color: #8ec7ff; border-radius: 999px; padding: 0.18rem 0.45rem; font-size: 0.72rem;"
+  end
+end

--- a/roundtable/lib/roundtable_web/live/landing_live.ex
+++ b/roundtable/lib/roundtable_web/live/landing_live.ex
@@ -37,6 +37,9 @@ defmodule RoundtableWeb.LandingLive do
             <a href={"/forgejo-shell?demo=#{@recommended_demo.id}"} style={cta_style(:primary)}>
               Open Recommended Demo
             </a>
+            <a href="/board" style={cta_style(:secondary)}>
+              Open Board
+            </a>
             <a href="/roundtable" style={cta_style(:secondary)}>
               Open Roundtable Ops
             </a>

--- a/roundtable/lib/roundtable_web/router.ex
+++ b/roundtable/lib/roundtable_web/router.ex
@@ -20,6 +20,7 @@ defmodule RoundtableWeb.Router do
     get("/auth/sign_out", AuthController, :sign_out)
 
     live("/", LandingLive)
+    live("/board", BoardLive)
 
     live_session :authenticated, on_mount: [{RoundtableWeb.UserAuth, :ensure_authenticated}] do
       live("/roundtable", DiscussionLive)

--- a/roundtable/test/roundtable/board_kanban_read_model_test.exs
+++ b/roundtable/test/roundtable/board_kanban_read_model_test.exs
@@ -1,0 +1,176 @@
+defmodule Roundtable.BoardKanbanReadModelTest do
+  use ExUnit.Case, async: true
+
+  alias Roundtable.BoardKanbanReadModel
+
+  defmodule FakeBoard do
+    def list_work_items(_repo_path, _opts) do
+      {:ok,
+       [
+         %{
+           id: "wk-queued",
+           repo_ref: "deepwatrcreatur/agent-roundtable",
+           branch_ref: "feat/queued",
+           title: "Queued work",
+           task_type: "code_change",
+           priority: 10,
+           status: "queued",
+           updated_at: "2026-05-23T00:00:00Z"
+         },
+         %{
+           id: "wk-gated",
+           repo_ref: "deepwatrcreatur/agent-roundtable",
+           branch_ref: "feat/gated",
+           title: "Needs approval",
+           task_type: "deploy",
+           priority: 20,
+           status: "awaiting_human_input",
+           updated_at: "2026-05-23T00:05:00Z"
+         },
+         %{
+           id: "wk-running",
+           repo_ref: "deepwatrcreatur/agent-roundtable",
+           branch_ref: "feat/running",
+           title: "Runtime drift",
+           task_type: "benchmark",
+           priority: 30,
+           status: "running",
+           updated_at: "2026-05-23T00:10:00Z"
+         },
+         %{
+           id: "wk-done",
+           repo_ref: "deepwatrcreatur/agent-roundtable",
+           branch_ref: "feat/done",
+           title: "Completed work",
+           task_type: "review",
+           priority: 40,
+           status: "succeeded",
+           updated_at: "2026-05-23T00:20:00Z"
+         }
+       ]}
+    end
+
+    def list_attempts(_repo_path, "wk-queued", _opts), do: {:ok, []}
+
+    def list_attempts(_repo_path, "wk-gated", _opts) do
+      {:ok,
+       [
+         %{
+           id: "att-2",
+           work_item_id: "wk-gated",
+           attempt_number: 1,
+           runtime_id: "rtk-1",
+           status: "running",
+           lease_expires_at: "2026-05-23T01:07:00Z",
+           summary: "Waiting for approval",
+           exit_class: "needs_human_gate",
+           started_at: "2026-05-23T00:50:00Z"
+         }
+       ]}
+    end
+
+    def list_attempts(_repo_path, "wk-running", _opts) do
+      {:ok,
+       [
+         %{
+           id: "att-3",
+           work_item_id: "wk-running",
+           attempt_number: 2,
+           runtime_id: "rtk-2",
+           status: "running",
+           lease_expires_at: "2026-05-23T00:59:00Z",
+           summary: "Benchmark in progress",
+           exit_class: nil,
+           started_at: "2026-05-23T00:40:00Z"
+         }
+       ]}
+    end
+
+    def list_attempts(_repo_path, "wk-done", _opts) do
+      {:ok,
+       [
+         %{
+           id: "att-4",
+           work_item_id: "wk-done",
+           attempt_number: 1,
+           runtime_id: "rtk-1",
+           status: "succeeded",
+           lease_expires_at: nil,
+           summary: "Validation passed",
+           exit_class: "success",
+           started_at: "2026-05-23T00:00:00Z",
+           finished_at: "2026-05-23T00:15:00Z"
+         }
+       ]}
+    end
+
+    def list_human_gates(_repo_path, "wk-gated", _opts) do
+      {:ok,
+       [
+         %{
+           id: "gate-1",
+           work_item_id: "wk-gated",
+           attempt_id: "att-2",
+           gate_type: "approve",
+           state: "open",
+           prompt: "Ship this?",
+           created_at: "2026-05-23T00:55:00Z"
+         }
+       ]}
+    end
+
+    def list_human_gates(_repo_path, _work_item_id, _opts), do: {:ok, []}
+
+    def list_runtime_heartbeats(_repo_path, _opts) do
+      {:ok,
+       [
+         %{runtime_id: "rtk-1", host_label: "runner-1", status: "busy", last_seen_at: "2026-05-23T00:57:00Z"},
+         %{runtime_id: "rtk-2", host_label: "runner-2", status: "offline", last_seen_at: "2026-05-23T00:45:00Z"}
+       ]}
+    end
+
+    def list_attempt_events(_repo_path, "att-2", _opts) do
+      {:ok,
+       [
+         %{id: "evt-1", attempt_id: "att-2", event_type: "needs_human_gate", summary: "Approval required", created_at: "2026-05-23T00:56:00Z"}
+       ]}
+    end
+
+    def list_attempt_events(_repo_path, "att-3", _opts) do
+      {:ok,
+       [
+         %{id: "evt-2", attempt_id: "att-3", event_type: "progress", summary: "Still running benchmarks", created_at: "2026-05-23T00:58:30Z"}
+       ]}
+    end
+
+    def list_attempt_events(_repo_path, "att-4", _opts), do: {:ok, []}
+  end
+
+  test "derives lanes, badges, and attention alerts from canonical board state" do
+    now = ~U[2026-05-23 01:00:00Z]
+
+    assert {:ok, snapshot} =
+             BoardKanbanReadModel.snapshot(
+               "/tmp/repo",
+               board: FakeBoard,
+               now: now
+             )
+
+    cards = Map.new(snapshot.cards, &{&1.work_item_id, &1})
+
+    assert cards["wk-queued"].lane == "queued"
+    assert cards["wk-gated"].lane == "gated"
+    assert cards["wk-gated"].gate_type == "approve"
+    assert "gate:open" in cards["wk-gated"].badge_refs
+
+    assert cards["wk-running"].lane == "attention"
+    assert "runtime_offline" in cards["wk-running"].alert_refs
+    assert "lease:expired" in cards["wk-running"].badge_refs
+
+    assert cards["wk-done"].lane == "done"
+    assert snapshot.counts["queued"] == 1
+    assert snapshot.counts["gated"] == 1
+    assert snapshot.counts["attention"] == 1
+    assert snapshot.counts["done"] == 1
+  end
+end

--- a/roundtable/test/roundtable_web/board_live_test.exs
+++ b/roundtable/test/roundtable_web/board_live_test.exs
@@ -1,0 +1,148 @@
+defmodule RoundtableWeb.BoardLiveTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.Component
+  import Phoenix.LiveViewTest
+
+  alias Roundtable.BoardKanbanReadModel
+  alias RoundtableWeb.BoardLive
+
+  defmodule FakeBoard do
+    def list_work_items(_repo_path, _opts) do
+      {:ok,
+       [
+         %{
+           id: "wk-1",
+           repo_ref: "deepwatrcreatur/agent-roundtable",
+           branch_ref: "feat/board",
+           title: "Queued card",
+           task_type: "code_change",
+           priority: 10,
+           status: "queued",
+           updated_at: "2026-05-23T00:00:00Z"
+         },
+         %{
+           id: "wk-2",
+           repo_ref: "deepwatrcreatur/unified-nix-configuration",
+           branch_ref: "feat/deploy",
+           title: "Needs approval",
+           task_type: "deploy",
+           priority: 20,
+           status: "awaiting_human_input",
+           updated_at: "2026-05-23T00:05:00Z"
+         }
+       ]}
+    end
+
+    def list_attempts(_repo_path, "wk-1", _opts), do: {:ok, []}
+
+    def list_attempts(_repo_path, "wk-2", _opts) do
+      {:ok,
+       [
+         %{
+           id: "att-2",
+           work_item_id: "wk-2",
+           attempt_number: 1,
+           runtime_id: "rtk-1",
+           status: "running",
+           lease_expires_at: "2026-05-23T01:07:00Z",
+           summary: "Awaiting approval",
+           exit_class: "needs_human_gate",
+           started_at: "2026-05-23T00:50:00Z"
+         }
+       ]}
+    end
+
+    def list_human_gates(_repo_path, "wk-2", _opts) do
+      {:ok,
+       [
+         %{
+           id: "gate-1",
+           work_item_id: "wk-2",
+           attempt_id: "att-2",
+           gate_type: "approve",
+           state: "open",
+           prompt: "Promote now?",
+           created_at: "2026-05-23T00:56:00Z"
+         }
+       ]}
+    end
+
+    def list_human_gates(_repo_path, _work_item_id, _opts), do: {:ok, []}
+
+    def list_runtime_heartbeats(_repo_path, _opts) do
+      {:ok, [%{runtime_id: "rtk-1", host_label: "runner-1", status: "busy", last_seen_at: "2026-05-23T00:57:00Z"}]}
+    end
+
+    def list_attempt_events(_repo_path, "att-2", _opts) do
+      {:ok,
+       [
+         %{id: "evt-1", attempt_id: "att-2", event_type: "needs_human_gate", summary: "Approval required", created_at: "2026-05-23T00:56:00Z"}
+       ]}
+    end
+  end
+
+  test "render shows board lanes, cards, and selected detail" do
+    now = ~U[2026-05-23 01:00:00Z]
+
+    {:ok, snapshot} = BoardKanbanReadModel.snapshot("/tmp/repo", board: FakeBoard, now: now)
+    selected = Enum.find(snapshot.cards, &(&1.work_item_id == "wk-2"))
+
+    html =
+      %{
+        __changed__: %{},
+        repo_path: "/tmp/repo",
+        params: %{},
+        filters: snapshot.filters,
+        counts: snapshot.counts,
+        snapshot_generated_at: snapshot.generated_at,
+        error: nil,
+        cards: snapshot.cards,
+        lanes: snapshot.lanes,
+        selected_card: selected
+      }
+      |> BoardLive.render()
+      |> rendered_to_string()
+
+    assert html =~ "Vaglio Board"
+    assert html =~ "Queued"
+    assert html =~ "Gated"
+    assert html =~ "Queued card"
+    assert html =~ "Needs approval"
+    assert html =~ "Approval required"
+    assert html =~ "Selected card"
+  end
+
+  test "render can show a pre-filtered repo slice" do
+    now = ~U[2026-05-23 01:00:00Z]
+    {:ok, snapshot} = BoardKanbanReadModel.snapshot("/tmp/repo", board: FakeBoard, now: now)
+
+    cards = Enum.filter(snapshot.cards, &(&1.repo_ref == "deepwatrcreatur/unified-nix-configuration"))
+    card_ids = MapSet.new(Enum.map(cards, & &1.work_item_id))
+    lanes =
+      Enum.map(snapshot.lanes, fn lane ->
+        Map.update!(lane, :cards, fn lane_cards ->
+          Enum.filter(lane_cards, fn card -> MapSet.member?(card_ids, card.work_item_id) end)
+        end)
+      end)
+
+    html =
+      %{
+        __changed__: %{},
+        repo_path: "/tmp/repo",
+        params: %{"repo" => "deepwatrcreatur/unified-nix-configuration"},
+        filters: snapshot.filters,
+        counts: snapshot.counts,
+        snapshot_generated_at: snapshot.generated_at,
+        error: nil,
+        cards: cards,
+        lanes: lanes,
+        selected_card: List.first(cards)
+      }
+      |> BoardLive.render()
+      |> rendered_to_string()
+
+    assert html =~ "Needs approval"
+    refute html =~ "Queued card"
+  end
+end


### PR DESCRIPTION
Summary:
- add a browse-first board surface on the existing Phoenix app
- derive kanban lanes, card summaries, alerts, and detail state from canonical board tables
- mark work item 97 done and cover the read model and board render path with focused tests

Testing:
- nix develop . --command bash -lc 'cd roundtable && mix test test/roundtable/board_kanban_read_model_test.exs test/roundtable_web/board_live_test.exs'