### PR TITLE
fix: initialize board repo for vaglio

### DIFF
--- a/nix/modules/profiles/vaglio-base.nix
+++ b/nix/modules/profiles/vaglio-base.nix
@@ -41,6 +41,7 @@
     enable = true;
     enableTuiTooling = true;
     phoenixHost = "roundtable.deepwatercreature.com";
+    boardRepoPath = "/var/lib/roundtable/state/board-repo";
   };
 
   system.stateVersion = lib.mkDefault "25.11";

--- a/nix/modules/services/roundtable.nix
+++ b/nix/modules/services/roundtable.nix
@@ -8,6 +8,8 @@
 let
   cfg = config.services.roundtable;
   stateHome = "/var/lib/${cfg.stateDir}";
+  boardRepoPath =
+    if cfg.boardRepoPath != "" then cfg.boardRepoPath else "${stateHome}/board";
 
   credential =
     name: file:
@@ -75,6 +77,12 @@ in
       type = lib.types.str;
       default = "";
       description = "Optional local discussion repo path used for conflict inspection.";
+    };
+
+    boardRepoPath = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "Optional local Dolt repo path used by the board surface and runtime state.";
     };
 
     stateDir = lib.mkOption {
@@ -170,11 +178,49 @@ in
         ++ cfg.extraPackages
       );
 
+    systemd.services.roundtable-init-board-repo = {
+      description = "Initialize the local Dolt repo used by the Vaglio board surface";
+      wantedBy = [ "multi-user.target" ];
+      before = [
+        "roundtable.service"
+        "roundtable-prewarm-public-repo-cache.service"
+      ];
+      path = with pkgs; [
+        coreutils
+        dolt
+      ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+
+      script = ''
+        set -eu
+
+        export HOME=${lib.escapeShellArg stateHome}
+        mkdir -p ${lib.escapeShellArg boardRepoPath}
+        cd ${lib.escapeShellArg boardRepoPath}
+
+        if ! dolt config --global --get user.name >/dev/null 2>&1; then
+          dolt config --global --add user.name "Roundtable"
+        fi
+
+        if ! dolt config --global --get user.email >/dev/null 2>&1; then
+          dolt config --global --add user.email "roundtable@localhost"
+        fi
+
+        if [ ! -d .dolt ]; then
+          dolt init -b main
+        fi
+      '';
+    };
+
     systemd.services.roundtable = {
       description = "Vaglio / roundtable discussion orchestrator";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
+      after = [ "network-online.target" "roundtable-init-board-repo.service" ];
+      wants = [ "network-online.target" "roundtable-init-board-repo.service" ];
       path = with pkgs; [
         coreutils
         openssl
@@ -209,6 +255,7 @@ in
             "OIDC_ISSUER_URL=${cfg.oidcIssuerUrl}"
             "ROUNDTABLE_REPO=${cfg.roundtableRepo}"
             "ROUNDTABLE_BRIEF=${cfg.roundtableBrief}"
+            "ROUNDTABLE_BOARD_REPO_PATH=${boardRepoPath}"
           ]
           ++ lib.optional (cfg.localPath != "") "ROUNDTABLE_LOCAL_PATH=${cfg.localPath}";
         ExecStart = pkgs.writeShellScript "roundtable-start" ''
@@ -243,8 +290,8 @@ in
     systemd.services.roundtable-prewarm-public-repo-cache = lib.mkIf cfg.prewarmPublicRepoCache.enable {
       description = "Warm cached public-repo snapshots for the roundtable demo";
       wantedBy = [ "multi-user.target" ];
-      after = [ "roundtable.service" ];
-      wants = [ "roundtable.service" ];
+      after = [ "roundtable-init-board-repo.service" "roundtable.service" ];
+      wants = [ "roundtable-init-board-repo.service" "roundtable.service" ];
       path = with pkgs; [
         coreutils
       ];

--- a/roundtable/lib/mix/tasks/roundtable.seed_board_demo.ex
+++ b/roundtable/lib/mix/tasks/roundtable.seed_board_demo.ex
@@ -1,0 +1,51 @@
+defmodule Mix.Tasks.Roundtable.SeedBoardDemo do
+  @shortdoc "Seed a small browseable board demo into a local board repo"
+
+  use Mix.Task
+
+  alias Roundtable.BoardDemoSeed
+
+  @impl true
+  def run(args) do
+    Mix.Task.run("app.start")
+    repo_path = parse_args(args)
+
+    case BoardDemoSeed.seed(repo_path) do
+      :ok ->
+        Mix.shell().info("seeded board demo into #{repo_path}")
+
+      {:error, reason} ->
+        Mix.raise("failed to seed board demo: #{inspect(reason)}")
+    end
+  end
+
+  @doc false
+  def parse_args(args) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args,
+        strict: [repo_path: :string]
+      )
+
+    if invalid != [] do
+      raise usage("invalid arguments: #{inspect(invalid)}")
+    end
+
+    case positional do
+      [] ->
+        Keyword.get(opts, :repo_path) ||
+          System.get_env("ROUNDTABLE_BOARD_REPO_PATH") ||
+          System.get_env("ROUNDTABLE_LOCAL_PATH") ||
+          raise usage("board repo path is required")
+
+      [repo_path] ->
+        repo_path
+
+      _ ->
+        raise usage("expected at most one positional repo path")
+    end
+  end
+
+  defp usage(reason) do
+    "#{reason}\nusage: mix roundtable.seed_board_demo [<repo-path>] [--repo-path <dir>]"
+  end
+end

--- a/roundtable/lib/roundtable/board_demo_seed.ex
+++ b/roundtable/lib/roundtable/board_demo_seed.ex
@@ -1,0 +1,355 @@
+defmodule Roundtable.BoardDemoSeed do
+  @moduledoc """
+  Seed a small browseable execution board demo into a local board repo.
+  """
+
+  alias Roundtable.Board
+
+  @timestamps %{
+    created: "2026-05-23T02:00:00Z",
+    queued_updated: "2026-05-23T02:03:00Z",
+    running_started: "2026-05-23T02:05:00Z",
+    running_updated: "2026-05-23T02:09:00Z",
+    gated_started: "2026-05-23T02:01:00Z",
+    gated_updated: "2026-05-23T02:11:00Z",
+    attention_started: "2026-05-23T01:20:00Z",
+    attention_updated: "2026-05-23T02:12:00Z",
+    done_started: "2026-05-23T00:45:00Z",
+    done_finished: "2026-05-23T01:10:00Z",
+    done_updated: "2026-05-23T01:10:00Z",
+    failed_started: "2026-05-23T01:40:00Z",
+    failed_finished: "2026-05-23T01:58:00Z",
+    failed_updated: "2026-05-23T01:58:00Z",
+    recent_runtime: "2026-05-23T02:12:30Z",
+    stale_runtime: "2026-05-23T01:15:00Z",
+    lease_healthy: "2026-05-23T03:45:00Z",
+    lease_expired: "2026-05-23T01:50:00Z",
+    gate_created: "2026-05-23T02:10:00Z"
+  }
+
+  @doc """
+  Seed a deterministic demo board into `repo_path`.
+  """
+  @spec seed(String.t(), keyword()) :: :ok | {:error, term()}
+  def seed(repo_path, opts \\ []) when is_binary(repo_path) do
+    board = Keyword.get(opts, :board, Board)
+    board_opts = Keyword.drop(opts, [:board])
+
+    with :ok <- seed_runtimes(repo_path, board, board_opts),
+         :ok <- seed_work_items(repo_path, board, board_opts),
+         :ok <- seed_attempts(repo_path, board, board_opts),
+         :ok <- seed_gates(repo_path, board, board_opts),
+         :ok <- seed_events(repo_path, board, board_opts) do
+      :ok
+    end
+  end
+
+  defp seed_runtimes(repo_path, board, opts) do
+    for runtime <- runtimes(), reduce: :ok do
+      :ok -> board.heartbeat_runtime(repo_path, runtime, opts)
+      error -> error
+    end
+  end
+
+  defp seed_work_items(repo_path, board, opts) do
+    for item <- work_items(), reduce: :ok do
+      :ok -> board.create_work_item(repo_path, item, opts)
+      error -> error
+    end
+  end
+
+  defp seed_attempts(repo_path, board, opts) do
+    for attempt <- attempts(), reduce: :ok do
+      :ok -> board.append_attempt(repo_path, attempt, opts)
+      error -> error
+    end
+  end
+
+  defp seed_gates(repo_path, board, opts) do
+    for gate <- human_gates(), reduce: :ok do
+      :ok -> board.open_human_gate(repo_path, gate, opts)
+      error -> error
+    end
+  end
+
+  defp seed_events(repo_path, board, opts) do
+    for event <- attempt_events(), reduce: :ok do
+      :ok -> board.append_attempt_event(repo_path, event, opts)
+      error -> error
+    end
+  end
+
+  defp runtimes do
+    [
+      %{
+        runtime_id: "runtime-vaglio-main",
+        host_label: "vaglio main runtime",
+        transport: "systemd",
+        status: "busy",
+        capabilities: %{profiles: ["codex", "review"], resource_scope: "host:vaglio"},
+        active_attempt_id: "att-running-1",
+        last_seen_at: @timestamps.recent_runtime,
+        metadata: %{host: "vaglio", role: "executor"}
+      },
+      %{
+        runtime_id: "runtime-vaglio-review",
+        host_label: "vaglio review lane",
+        transport: "systemd",
+        status: "degraded",
+        capabilities: %{profiles: ["review"], resource_scope: "host:vaglio"},
+        active_attempt_id: "att-gated-1",
+        last_seen_at: @timestamps.recent_runtime,
+        metadata: %{host: "vaglio", role: "review"}
+      },
+      %{
+        runtime_id: "runtime-vaglio-ops",
+        host_label: "vaglio ops runtime",
+        transport: "systemd",
+        status: "offline",
+        capabilities: %{profiles: ["ops"], resource_scope: "host:vaglio"},
+        active_attempt_id: "att-attention-1",
+        last_seen_at: @timestamps.stale_runtime,
+        metadata: %{host: "vaglio", role: "ops"}
+      }
+    ]
+  end
+
+  defp work_items do
+    [
+      %{
+        id: "wk-gated",
+        repo_ref: "deepwatrcreatur/agent-roundtable",
+        branch_ref: "fix/board-repo-path",
+        source_ref: "round-103",
+        title: "Review board repo bootstrap on vaglio",
+        task_type: "code_change",
+        input_payload: %{pr: 103, surface: "/board"},
+        desired_outcome: %{result: "board route stays live after switch"},
+        status: "running",
+        priority: 10,
+        assignee_type: "agent",
+        assignee_ref: "codex-gpt54",
+        workflow_ref: "wf-review",
+        retry_policy: %{max_attempts: 2},
+        timeout_policy: %{hard_timeout_s: 1800},
+        hitl_policy: %{gate: "approve"},
+        created_at: @timestamps.created,
+        updated_at: @timestamps.gated_updated
+      },
+      %{
+        id: "wk-attention",
+        repo_ref: "deepwatrcreatur/agent-roundtable",
+        branch_ref: "main",
+        source_ref: "round-88",
+        title: "Repair stalled public repo cache warm path",
+        task_type: "ops_repair",
+        input_payload: %{surface: "/forgejo-shell", concern: "cache warm"},
+        desired_outcome: %{result: "all demo caches hot"},
+        status: "running",
+        priority: 20,
+        assignee_type: "agent",
+        assignee_ref: "codex-gpt54",
+        workflow_ref: "wf-ops",
+        retry_policy: %{max_attempts: 3},
+        timeout_policy: %{hard_timeout_s: 900},
+        hitl_policy: %{gate: "notify"},
+        created_at: @timestamps.created,
+        updated_at: @timestamps.attention_updated
+      },
+      %{
+        id: "wk-running",
+        repo_ref: "deepwatrcreatur/agent-roundtable",
+        branch_ref: "main",
+        source_ref: "round-102",
+        title: "Polish browseable board surface for public demos",
+        task_type: "ui_polish",
+        input_payload: %{route: "/board", audience: "operators"},
+        desired_outcome: %{result: "legible live board"},
+        status: "running",
+        priority: 30,
+        assignee_type: "agent",
+        assignee_ref: "codex-gpt54",
+        workflow_ref: "wf-ui",
+        retry_policy: %{max_attempts: 2},
+        timeout_policy: %{hard_timeout_s: 1200},
+        hitl_policy: %{gate: "none"},
+        created_at: @timestamps.created,
+        updated_at: @timestamps.running_updated
+      },
+      %{
+        id: "wk-queued",
+        repo_ref: "deepwatrcreatur/agent-roundtable",
+        branch_ref: "main",
+        source_ref: "round-95",
+        title: "Thread Sourcegraph evidence into subtree briefs",
+        task_type: "analysis",
+        input_payload: %{adapter: "sourcegraph", surface: "subtree_brief"},
+        desired_outcome: %{result: "bounded semantic evidence in brief"},
+        status: "queued",
+        priority: 40,
+        assignee_type: "agent",
+        assignee_ref: "codex-gpt54",
+        workflow_ref: "wf-analysis",
+        retry_policy: %{max_attempts: 2},
+        timeout_policy: %{hard_timeout_s: 1800},
+        hitl_policy: %{gate: "none"},
+        created_at: @timestamps.created,
+        updated_at: @timestamps.queued_updated
+      },
+      %{
+        id: "wk-done",
+        repo_ref: "deepwatrcreatur/agent-roundtable",
+        branch_ref: "main",
+        source_ref: "round-89",
+        title: "Ship shareable public repo reports page",
+        task_type: "deployment",
+        input_payload: %{route: "/forgejo-shell/reports"},
+        desired_outcome: %{result: "public reports route live"},
+        status: "succeeded",
+        priority: 50,
+        assignee_type: "agent",
+        assignee_ref: "codex-gpt54",
+        workflow_ref: "wf-deploy",
+        retry_policy: %{max_attempts: 1},
+        timeout_policy: %{hard_timeout_s: 1200},
+        hitl_policy: %{gate: "none"},
+        created_at: @timestamps.created,
+        updated_at: @timestamps.done_updated,
+        closed_at: @timestamps.done_finished
+      },
+      %{
+        id: "wk-closed",
+        repo_ref: "deepwatrcreatur/agent-roundtable",
+        branch_ref: "docs/vaglio-single-writer-lock",
+        source_ref: "round-78",
+        title: "Stabilize overlapping host deploy attempts",
+        task_type: "ops_policy",
+        input_payload: %{resource: "host:vaglio"},
+        desired_outcome: %{result: "single-writer deploy policy"},
+        status: "failed",
+        priority: 60,
+        assignee_type: "agent",
+        assignee_ref: "codex-gpt54",
+        workflow_ref: "wf-policy",
+        retry_policy: %{max_attempts: 1},
+        timeout_policy: %{hard_timeout_s: 900},
+        hitl_policy: %{gate: "operator"},
+        created_at: @timestamps.created,
+        updated_at: @timestamps.failed_updated,
+        closed_at: @timestamps.failed_finished
+      }
+    ]
+  end
+
+  defp attempts do
+    [
+      %{
+        id: "att-gated-1",
+        work_item_id: "wk-gated",
+        attempt_number: 1,
+        runtime_id: "runtime-vaglio-review",
+        agent_id: "codex-gpt54",
+        status: "running",
+        lease_expires_at: @timestamps.lease_healthy,
+        started_at: @timestamps.gated_started,
+        summary: "Board bootstrap patch is waiting for operator approval"
+      },
+      %{
+        id: "att-attention-1",
+        work_item_id: "wk-attention",
+        attempt_number: 1,
+        runtime_id: "runtime-vaglio-ops",
+        agent_id: "codex-gpt54",
+        status: "running",
+        lease_expires_at: @timestamps.lease_expired,
+        started_at: @timestamps.attention_started,
+        summary: "Cache warm path lost ownership during deploy churn"
+      },
+      %{
+        id: "att-running-1",
+        work_item_id: "wk-running",
+        attempt_number: 1,
+        runtime_id: "runtime-vaglio-main",
+        agent_id: "codex-gpt54",
+        status: "running",
+        lease_expires_at: @timestamps.lease_healthy,
+        started_at: @timestamps.running_started,
+        summary: "Rendering the board surface against canonical board state"
+      },
+      %{
+        id: "att-done-1",
+        work_item_id: "wk-done",
+        attempt_number: 1,
+        runtime_id: "runtime-vaglio-main",
+        agent_id: "codex-gpt54",
+        status: "succeeded",
+        lease_expires_at: nil,
+        started_at: @timestamps.done_started,
+        finished_at: @timestamps.done_finished,
+        exit_class: "success",
+        summary: "Reports page deployed and verified"
+      },
+      %{
+        id: "att-closed-1",
+        work_item_id: "wk-closed",
+        attempt_number: 1,
+        runtime_id: "runtime-vaglio-ops",
+        agent_id: "codex-gpt54",
+        status: "failed",
+        lease_expires_at: nil,
+        started_at: @timestamps.failed_started,
+        finished_at: @timestamps.failed_finished,
+        exit_class: "tool_error",
+        summary: "Concurrent deploy attempts contended on the same mutable host",
+        error_excerpt: "runtime wrapper state collided across agents"
+      }
+    ]
+  end
+
+  defp human_gates do
+    [
+      %{
+        id: "gate-gated-1",
+        work_item_id: "wk-gated",
+        attempt_id: "att-gated-1",
+        gate_type: "approve",
+        prompt: "Promote the persistent board-repo bootstrap fix to main?",
+        options: ["approve", "request changes", "hold"],
+        state: "open",
+        created_at: @timestamps.gate_created
+      }
+    ]
+  end
+
+  defp attempt_events do
+    [
+      %{
+        id: "evt-gated-1",
+        attempt_id: "att-gated-1",
+        work_item_id: "wk-gated",
+        event_type: "waiting_for_review",
+        summary: "Operator review requested before promoting the board bootstrap change",
+        metadata: %{surface: "/board", gate: "approve"},
+        created_at: @timestamps.gate_created
+      },
+      %{
+        id: "evt-attention-1",
+        attempt_id: "att-attention-1",
+        work_item_id: "wk-attention",
+        event_type: "lease_expired",
+        summary: "Public repo cache warm lane needs an operator handoff",
+        metadata: %{resource_scope: "cache:public-repo-demo"},
+        created_at: @timestamps.attention_updated
+      },
+      %{
+        id: "evt-running-1",
+        attempt_id: "att-running-1",
+        work_item_id: "wk-running",
+        event_type: "progress",
+        summary: "Board cards now reflect lane projections over canonical state",
+        metadata: %{surface: "/board"},
+        created_at: @timestamps.running_updated
+      }
+    ]
+  end
+end

--- a/roundtable/lib/roundtable/vcs/dolt.ex
+++ b/roundtable/lib/roundtable/vcs/dolt.ex
@@ -19,8 +19,9 @@ defmodule Roundtable.Vcs.Dolt do
   @impl true
   def current_head(branch, opts) when is_binary(branch) do
     with {:ok, repo_path} <- fetch_repo_path(opts),
-         {:ok, head} <- dolt(["rev-parse", branch], repo_path, opts) do
-      {:ok, String.trim(head)}
+         {:ok, output} <- dolt(["log", "-n", "1", "--oneline", branch], repo_path, opts),
+         {:ok, head} <- parse_log_head(output) do
+      {:ok, head}
     end
   end
 
@@ -30,10 +31,9 @@ defmodule Roundtable.Vcs.Dolt do
     # or if we are using it to version raw files (less common).
     # For now, we'll assume read_file for Dolt means reading a table as JSON/CSV.
     with {:ok, repo_path} <- fetch_repo_path(opts) do
-      revision = Keyword.get(opts, :revision, "HEAD")
       # Example: dolt sql -q "SELECT * FROM <table>"
       case dolt(
-             ["sql", "-r", revision, "-q", "SELECT * FROM `#{path}`", "-r", "json"],
+             ["sql", "-q", "SELECT * FROM `#{path}`", "-r", "json"],
              repo_path,
              opts
            ) do
@@ -59,15 +59,21 @@ defmodule Roundtable.Vcs.Dolt do
   @impl true
   def query(sql, opts) when is_binary(sql) do
     with {:ok, repo_path} <- fetch_repo_path(opts) do
-      revision = Keyword.get(opts, :revision, "HEAD")
-
-      case dolt(["sql", "-r", revision, "-q", sql, "-r", "json"], repo_path, opts) do
+      case dolt(["sql", "-q", sql, "-r", "json"], repo_path, opts) do
         {:ok, content} ->
-          case Jason.decode(content) do
-            {:ok, %{"rows" => rows}} -> {:ok, rows}
-            {:ok, []} -> {:ok, []}
-            {:ok, _} -> {:ok, []}
-            {:error, _} = err -> err
+          trimmed = String.trim(content)
+
+          cond do
+            trimmed == "" ->
+              {:ok, []}
+
+            true ->
+              case Jason.decode(trimmed) do
+                {:ok, %{"rows" => rows}} -> {:ok, rows}
+                {:ok, []} -> {:ok, []}
+                {:ok, _} -> {:ok, []}
+                {:error, _} = err -> err
+              end
           end
 
         {:error, _} = err ->
@@ -86,8 +92,7 @@ defmodule Roundtable.Vcs.Dolt do
     # We assume the caller has already performed SQL updates via a separate action.
     with {:ok, repo_path} <- fetch_repo_path(opts),
          {:ok, _} <- dolt(["add", "."], repo_path, opts),
-         {:ok, _} <- dolt(commit_args(params), repo_path, opts),
-         {:ok, commit_sha} <- current_head(branch, opts) do
+         {:ok, commit_sha} <- commit_or_current_head(repo_path, branch, params, opts) do
       {:ok, %{commit_id: commit_sha, change_id: nil, branch: branch}}
     end
   end
@@ -101,6 +106,30 @@ defmodule Roundtable.Vcs.Dolt do
 
   defp signing_args(%{sign?: true}), do: ["-S"]
   defp signing_args(_params), do: []
+
+  defp commit_or_current_head(repo_path, branch, params, opts) do
+    case dolt(commit_args(params), repo_path, opts) do
+      {:ok, _} ->
+        current_head(branch, opts)
+
+      {:error, {:command_failed, 1, output}} = err ->
+        if String.contains?(output, "no changes added to commit") do
+          current_head(branch, opts)
+        else
+          err
+        end
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp parse_log_head(output) do
+    case output |> String.trim() |> String.split(~r/\s+/, parts: 2) do
+      [head | _rest] when head != "" -> {:ok, head}
+      _ -> {:error, {:unexpected_log_output, output}}
+    end
+  end
 
   defp fetch_repo_path(opts) do
     case Keyword.get(opts, :repo_path) do

--- a/roundtable/lib/roundtable_web/layouts.ex
+++ b/roundtable/lib/roundtable_web/layouts.ex
@@ -44,6 +44,9 @@ defmodule RoundtableWeb.Layouts do
               <a href="/forgejo-shell" style="text-decoration: none; color: #c9d1d9; border: 1px solid #30363d; border-radius: 999px; padding: 0.35rem 0.75rem; font-size: 0.82rem;">
                 Forgejo Demo Shell
               </a>
+              <a href="/board" style="text-decoration: none; color: #c9d1d9; border: 1px solid #30363d; border-radius: 999px; padding: 0.35rem 0.75rem; font-size: 0.82rem;">
+                Board
+              </a>
               <a href="/roundtable" style="text-decoration: none; color: #c9d1d9; border: 1px solid #30363d; border-radius: 999px; padding: 0.35rem 0.75rem; font-size: 0.82rem;">
                 Roundtable Ops
               </a>

--- a/roundtable/test/roundtable/board_demo_seed_test.exs
+++ b/roundtable/test/roundtable/board_demo_seed_test.exs
@@ -1,0 +1,80 @@
+defmodule Roundtable.BoardDemoSeedTest do
+  use ExUnit.Case, async: true
+
+  alias Roundtable.BoardDemoSeed
+
+  defmodule FakeBoard do
+    def heartbeat_runtime(_repo_path, attrs, _opts) do
+      send(self(), {:heartbeat_runtime, attrs})
+      :ok
+    end
+
+    def create_work_item(_repo_path, attrs, _opts) do
+      send(self(), {:create_work_item, attrs})
+      :ok
+    end
+
+    def append_attempt(_repo_path, attrs, _opts) do
+      send(self(), {:append_attempt, attrs})
+      :ok
+    end
+
+    def open_human_gate(_repo_path, attrs, _opts) do
+      send(self(), {:open_human_gate, attrs})
+      :ok
+    end
+
+    def append_attempt_event(_repo_path, attrs, _opts) do
+      send(self(), {:append_attempt_event, attrs})
+      :ok
+    end
+  end
+
+  test "seed writes a representative set of board records" do
+    assert :ok = BoardDemoSeed.seed("/tmp/repo", board: FakeBoard)
+
+    heartbeats = drain(:heartbeat_runtime)
+    work_items = drain(:create_work_item)
+    attempts = drain(:append_attempt)
+    gates = drain(:open_human_gate)
+    events = drain(:append_attempt_event)
+
+    assert length(heartbeats) == 3
+    assert Enum.any?(heartbeats, &(&1.runtime_id == "runtime-vaglio-ops" and &1.status == "offline"))
+
+    assert length(work_items) == 6
+    assert Enum.any?(work_items, &(&1.id == "wk-queued" and &1.status == "queued"))
+    assert Enum.any?(work_items, &(&1.id == "wk-gated" and &1.priority == 10))
+    assert Enum.any?(work_items, &(&1.id == "wk-done" and &1.status == "succeeded"))
+
+    assert length(attempts) == 5
+    assert Enum.any?(attempts, &(&1.id == "att-attention-1" and &1.status == "running"))
+    assert Enum.any?(attempts, &(&1.id == "att-closed-1" and &1.exit_class == "tool_error"))
+
+    assert gates == [
+             %{
+               attempt_id: "att-gated-1",
+               created_at: "2026-05-23T02:10:00Z",
+               gate_type: "approve",
+               id: "gate-gated-1",
+               options: ["approve", "request changes", "hold"],
+               prompt: "Promote the persistent board-repo bootstrap fix to main?",
+               state: "open",
+               work_item_id: "wk-gated"
+             }
+           ]
+
+    assert length(events) == 3
+    assert Enum.any?(events, &(&1.id == "evt-running-1"))
+  end
+
+  defp drain(tag), do: drain(tag, [])
+
+  defp drain(tag, acc) do
+    receive do
+      {^tag, attrs} -> drain(tag, [attrs | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+end

--- a/roundtable/test/roundtable/mix_tasks/seed_board_demo_test.exs
+++ b/roundtable/test/roundtable/mix_tasks/seed_board_demo_test.exs
@@ -1,0 +1,23 @@
+defmodule Mix.Tasks.Roundtable.SeedBoardDemoTest do
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.Roundtable.SeedBoardDemo
+
+  test "parse_args accepts positional repo path" do
+    assert SeedBoardDemo.parse_args(["/tmp/board"]) == "/tmp/board"
+  end
+
+  test "parse_args accepts flag repo path" do
+    assert SeedBoardDemo.parse_args(["--repo-path", "/tmp/board"]) == "/tmp/board"
+  end
+
+  test "parse_args falls back to board env" do
+    System.put_env("ROUNDTABLE_BOARD_REPO_PATH", "/tmp/env-board")
+
+    try do
+      assert SeedBoardDemo.parse_args([]) == "/tmp/env-board"
+    after
+      System.delete_env("ROUNDTABLE_BOARD_REPO_PATH")
+    end
+  end
+end

--- a/roundtable/test/roundtable/vcs/dolt_test.exs
+++ b/roundtable/test/roundtable/vcs/dolt_test.exs
@@ -1,0 +1,76 @@
+defmodule Roundtable.Vcs.DoltTest do
+  use ExUnit.Case, async: true
+
+  alias Roundtable.Vcs.Dolt
+
+  defmodule FakeRunner do
+    def cmd(command, args, opts) do
+      send(self(), {:cmd, command, args, opts})
+      {~s({"rows":[]}), 0}
+    end
+  end
+
+  defmodule EmptyRunner do
+    def cmd(command, args, opts) do
+      send(self(), {:cmd, command, args, opts})
+      {"", 0}
+    end
+  end
+
+  defmodule NoChangeCommitRunner do
+    def cmd("dolt", ["add", "."], _opts), do: {"", 0}
+    def cmd("dolt", ["commit" | _rest], _opts), do: {"no changes added to commit (use \"dolt add\")\n", 1}
+    def cmd("dolt", ["log", "-n", "1", "--oneline", "main"], _opts), do: {"abc123 seed board\n", 0}
+  end
+
+  test "query uses dolt sql result-format without a duplicate revision flag" do
+    assert {:ok, []} =
+             Dolt.query(
+               "select * from work_items",
+               repo_path: "/tmp/board",
+               runner: FakeRunner
+             )
+
+    assert_received {:cmd, "dolt", args, [cd: "/tmp/board", stderr_to_stdout: true]}
+    assert args == ["sql", "-q", "select * from work_items", "-r", "json"]
+  end
+
+  test "read_file uses dolt sql result-format without a duplicate revision flag" do
+    assert {:ok, _json} =
+             Dolt.read_file(
+               "work_items",
+               repo_path: "/tmp/board",
+               runner: FakeRunner
+             )
+
+    assert_received {:cmd, "dolt", args, [cd: "/tmp/board", stderr_to_stdout: true]}
+    assert args == ["sql", "-q", "SELECT * FROM `work_items`", "-r", "json"]
+  end
+
+  test "query treats empty dolt output as an empty result set" do
+    assert {:ok, []} =
+             Dolt.query(
+               "create table if not exists work_items (id text)",
+               repo_path: "/tmp/board",
+               runner: EmptyRunner
+             )
+  end
+
+  test "write_files tolerates no-op commits after sql mutation" do
+    assert {:ok, %{commit_id: "abc123", branch: "main"}} =
+             Dolt.write_files(
+               %{message: "seed board", branch: "main", changes: []},
+               repo_path: "/tmp/board",
+               runner: NoChangeCommitRunner
+             )
+  end
+
+  test "current_head parses dolt log output" do
+    assert {:ok, "abc123"} =
+             Dolt.current_head(
+               "main",
+               repo_path: "/tmp/board",
+               runner: NoChangeCommitRunner
+             )
+  end
+end

--- a/roundtable/test/roundtable_web/navigation_test.exs
+++ b/roundtable/test/roundtable_web/navigation_test.exs
@@ -20,9 +20,11 @@ defmodule RoundtableWeb.NavigationTest do
     assert html =~ "Deepwater Roundtable"
     assert html =~ "Vaglio Demo Home"
     assert html =~ "Forgejo Demo Shell"
+    assert html =~ "Board"
     assert html =~ "Roundtable Ops"
     assert html =~ "Forgejo outside."
     assert html =~ "Open Recommended Demo"
+    assert html =~ "href=\"/board\""
     assert html =~ "href=\"/forgejo-shell\""
   end
 
@@ -33,7 +35,9 @@ defmodule RoundtableWeb.NavigationTest do
     assert html =~ "Deepwater Roundtable"
     assert html =~ "Vaglio Demo Home"
     assert html =~ "Forgejo Demo Shell"
+    assert html =~ "Board"
     assert html =~ "Roundtable Ops"
+    assert html =~ "href=\"/board\""
     assert html =~ "Inject Question"
   end
 
@@ -44,7 +48,9 @@ defmodule RoundtableWeb.NavigationTest do
     assert html =~ "Deepwater Roundtable"
     assert html =~ "Vaglio Demo Home"
     assert html =~ "Forgejo Demo Shell"
+    assert html =~ "Board"
     assert html =~ "Roundtable Ops"
+    assert html =~ "href=\"/board\""
     assert html =~ "href=\"/roundtable\""
   end
 end


### PR DESCRIPTION
## Summary
- give vaglio a stable board repo path under roundtable state
- initialize the local dolt board repo before the web service starts
- expose the Board surface in the shared top navigation

## Verification
- nix eval .#nixosConfigurations.vaglio.config.services.roundtable.boardRepoPath
- nix develop . --command bash -lc 'cd roundtable && mix deps.get && mix test test/roundtable_web/navigation_test.exs test/roundtable_web/board_live_test.exs'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Board" navigation link to the main navigation menu, providing access to the board surface.
  * Introduced board demo seeding functionality to populate demo data for testing and exploration purposes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/agent-roundtable/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->