### PR TITLE
feat: enrich board card context

### DIFF
--- a/roundtable/lib/roundtable/board_kanban_read_model.ex
+++ b/roundtable/lib/roundtable/board_kanban_read_model.ex
@@ -52,6 +52,10 @@ defmodule Roundtable.BoardKanbanReadModel do
     runtime_status = derive_runtime_status(runtime)
     status_conflict? = status_conflict?(item, current_attempt)
     superseded? = superseded_attempt?(current_attempt)
+    owner_ref = derive_owner_ref(item, current_attempt)
+    desired_outcome = desired_outcome_summary(item)
+    next_signal = derive_next_signal(open_gate, recent_event, current_attempt, desired_outcome)
+    freshness_state = derive_freshness_state(item, current_attempt, open_gate, runtime, recent_event, now)
 
     alert_refs =
       []
@@ -77,6 +81,12 @@ defmodule Roundtable.BoardKanbanReadModel do
       task_type: item.task_type,
       priority: item.priority,
       status: item.status,
+      source_ref: item.source_ref,
+      owner_ref: owner_ref,
+      desired_outcome: desired_outcome,
+      next_signal: next_signal,
+      gate_prompt: open_gate && open_gate.prompt,
+      freshness_state: freshness_state,
       current_attempt_ref: current_attempt && current_attempt.id,
       attempt_number: current_attempt && current_attempt.attempt_number,
       attempt_status: current_attempt && current_attempt.status,
@@ -239,6 +249,42 @@ defmodule Roundtable.BoardKanbanReadModel do
     end
   end
 
+  defp derive_owner_ref(item, nil), do: item.assignee_ref
+
+  defp derive_owner_ref(item, attempt) do
+    Map.get(attempt, :agent_id) || item.assignee_ref
+  end
+
+  defp desired_outcome_summary(item) do
+    outcome = item.desired_outcome
+
+    cond do
+      is_map(outcome) and is_binary(outcome["result"]) -> outcome["result"]
+      is_map(outcome) and is_binary(outcome[:result]) -> outcome[:result]
+      is_binary(outcome) -> outcome
+      true -> nil
+    end
+  end
+
+  defp derive_next_signal(open_gate, recent_event, current_attempt, desired_outcome) do
+    cond do
+      open_gate && open_gate.prompt not in [nil, ""] ->
+        open_gate.prompt
+
+      recent_event && recent_event.summary not in [nil, ""] ->
+        recent_event.summary
+
+      current_attempt && Map.get(current_attempt, :error_excerpt) not in [nil, ""] ->
+        Map.get(current_attempt, :error_excerpt)
+
+      desired_outcome not in [nil, ""] ->
+        desired_outcome
+
+      true ->
+        nil
+    end
+  end
+
   defp build_badges(item, attempt, runtime_status, gate_state, lease_state, alert_refs) do
     []
     |> add_badge("priority:high", item.priority && item.priority <= 25)
@@ -266,6 +312,22 @@ defmodule Roundtable.BoardKanbanReadModel do
     ]
     |> Enum.reject(&is_nil/1)
     |> Enum.max(fn -> item.updated_at || item.created_at end)
+  end
+
+  defp derive_freshness_state(item, attempt, gate, runtime, recent_event, now) do
+    case freshness_timestamp(item, attempt, gate, runtime, recent_event) |> parse_datetime() do
+      nil ->
+        "unknown"
+
+      timestamp ->
+        age_seconds = DateTime.diff(now, timestamp, :second)
+
+        cond do
+          age_seconds <= 900 -> "fresh"
+          age_seconds <= 3600 -> "watch"
+          true -> "stale"
+        end
+    end
   end
 
   defp add_badge(list, _badge, false), do: list
@@ -322,8 +384,10 @@ defmodule Roundtable.BoardKanbanReadModel do
 
   defp parse_datetime(value) when is_binary(value) do
     case DateTime.from_iso8601(value) do
-      {:ok, dt, _offset} -> dt
+      {:ok, datetime, _offset} -> datetime
       _ -> nil
     end
   end
+
+  defp parse_datetime(_value), do: nil
 end

--- a/roundtable/lib/roundtable_web/live/board_live.ex
+++ b/roundtable/lib/roundtable_web/live/board_live.ex
@@ -146,7 +146,15 @@ defmodule RoundtableWeb.BoardLive do
                   <div style="color: #8b949e; font-size: 0.78rem; white-space: nowrap;">{card.work_item_id}</div>
                 </div>
                 <div style="color: #58a6ff; font-size: 0.78rem; margin-bottom: 0.35rem;">{card.repo_ref}</div>
+                <div style="display: flex; gap: 0.45rem; flex-wrap: wrap; color: #8b949e; font-size: 0.76rem; margin-bottom: 0.35rem;">
+                  <span :if={card.owner_ref}>Owner {card.owner_ref}</span>
+                  <span :if={card.source_ref}>Source {card.source_ref}</span>
+                  <span>Freshness {freshness_label(card.freshness_state)}</span>
+                </div>
                 <div style="color: #8b949e; font-size: 0.83rem; line-height: 1.45; margin-bottom: 0.55rem;">{card.summary}</div>
+                <div :if={card.next_signal} style="color: #c9d1d9; font-size: 0.8rem; line-height: 1.4; margin-bottom: 0.55rem;">
+                  Next signal: {card.next_signal}
+                </div>
                 <div style="display: flex; gap: 0.35rem; flex-wrap: wrap;">
                   <span :for={badge <- Enum.take(card.badge_refs, 4)} style={badge_style(badge)}>{badge}</span>
                 </div>
@@ -166,10 +174,28 @@ defmodule RoundtableWeb.BoardLive do
             <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.55rem; margin-bottom: 0.9rem;">
               <.detail_metric label="Lane" value={@selected_card.lane} />
               <.detail_metric label="Status" value={@selected_card.status} />
+              <.detail_metric label="Owner" value={@selected_card.owner_ref || "unassigned"} />
+              <.detail_metric label="Source" value={@selected_card.source_ref || "n/a"} />
               <.detail_metric label="Runtime" value={@selected_card.runtime_ref || "unassigned"} />
               <.detail_metric label="Lease" value={@selected_card.lease_state} />
               <.detail_metric label="Gate" value={@selected_card.gate_type || @selected_card.gate_state} />
               <.detail_metric label="Attempt" value={detail_attempt(@selected_card)} />
+              <.detail_metric label="Freshness" value={freshness_label(@selected_card.freshness_state)} />
+              <.detail_metric label="Updated" value={@selected_card.updated_at || "unknown"} />
+            </div>
+
+            <div style="margin-bottom: 0.9rem;">
+              <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase; margin-bottom: 0.4rem;">Next signal</div>
+              <div style="background: rgba(13,17,23,0.86); border: 1px solid #30363d; border-radius: 10px; padding: 0.75rem; color: #c9d1d9; font-size: 0.84rem; line-height: 1.5;">
+                {@selected_card.next_signal || "No immediate signal recorded"}
+              </div>
+            </div>
+
+            <div :if={@selected_card.desired_outcome} style="margin-bottom: 0.9rem;">
+              <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase; margin-bottom: 0.4rem;">Desired outcome</div>
+              <div style="background: rgba(13,17,23,0.86); border: 1px solid #30363d; border-radius: 10px; padding: 0.75rem; color: #c9d1d9; font-size: 0.84rem; line-height: 1.5;">
+                {@selected_card.desired_outcome}
+              </div>
             </div>
 
             <div style="margin-bottom: 0.9rem;">
@@ -362,4 +388,9 @@ defmodule RoundtableWeb.BoardLive do
   defp badge_style(_badge) do
     "display: inline-flex; align-items: center; background: rgba(88,166,255,0.1); border: 1px solid rgba(88,166,255,0.22); color: #8ec7ff; border-radius: 999px; padding: 0.18rem 0.45rem; font-size: 0.72rem;"
   end
+
+  defp freshness_label("fresh"), do: "Fresh"
+  defp freshness_label("watch"), do: "Watch"
+  defp freshness_label("stale"), do: "Stale"
+  defp freshness_label(_other), do: "Unknown"
 end

--- a/roundtable/test/roundtable/board_kanban_read_model_test.exs
+++ b/roundtable/test/roundtable/board_kanban_read_model_test.exs
@@ -11,40 +11,52 @@ defmodule Roundtable.BoardKanbanReadModelTest do
            id: "wk-queued",
            repo_ref: "deepwatrcreatur/agent-roundtable",
            branch_ref: "feat/queued",
+           source_ref: "round-queued",
            title: "Queued work",
            task_type: "code_change",
            priority: 10,
            status: "queued",
+           assignee_ref: "codex-queued",
+           desired_outcome: %{"result" => "Queue should stay visible"},
            updated_at: "2026-05-23T00:00:00Z"
          },
          %{
            id: "wk-gated",
            repo_ref: "deepwatrcreatur/agent-roundtable",
            branch_ref: "feat/gated",
+           source_ref: "round-gated",
            title: "Needs approval",
            task_type: "deploy",
            priority: 20,
            status: "awaiting_human_input",
+           assignee_ref: "codex-review",
+           desired_outcome: %{"result" => "Ship after approval"},
            updated_at: "2026-05-23T00:05:00Z"
          },
          %{
            id: "wk-running",
            repo_ref: "deepwatrcreatur/agent-roundtable",
            branch_ref: "feat/running",
+           source_ref: "round-running",
            title: "Runtime drift",
            task_type: "benchmark",
            priority: 30,
            status: "running",
+           assignee_ref: "codex-bench",
+           desired_outcome: %{"result" => "Benchmarks complete"},
            updated_at: "2026-05-23T00:10:00Z"
          },
          %{
            id: "wk-done",
            repo_ref: "deepwatrcreatur/agent-roundtable",
            branch_ref: "feat/done",
+           source_ref: "round-done",
            title: "Completed work",
            task_type: "review",
            priority: 40,
            status: "succeeded",
+           assignee_ref: "codex-review",
+           desired_outcome: %{"result" => "Validation passes"},
            updated_at: "2026-05-23T00:20:00Z"
          }
        ]}
@@ -162,10 +174,15 @@ defmodule Roundtable.BoardKanbanReadModelTest do
     assert cards["wk-gated"].lane == "gated"
     assert cards["wk-gated"].gate_type == "approve"
     assert "gate:open" in cards["wk-gated"].badge_refs
+    assert cards["wk-gated"].owner_ref == "codex-review"
+    assert cards["wk-gated"].next_signal == "Ship this?"
+    assert cards["wk-gated"].freshness_state == "fresh"
 
     assert cards["wk-running"].lane == "attention"
     assert "runtime_offline" in cards["wk-running"].alert_refs
     assert "lease:expired" in cards["wk-running"].badge_refs
+    assert cards["wk-running"].next_signal == "Still running benchmarks"
+    assert cards["wk-running"].freshness_state == "fresh"
 
     assert cards["wk-done"].lane == "done"
     assert snapshot.counts["queued"] == 1

--- a/roundtable/test/roundtable_web/board_live_test.exs
+++ b/roundtable/test/roundtable_web/board_live_test.exs
@@ -11,27 +11,33 @@ defmodule RoundtableWeb.BoardLiveTest do
     def list_work_items(_repo_path, _opts) do
       {:ok,
        [
-         %{
-           id: "wk-1",
-           repo_ref: "deepwatrcreatur/agent-roundtable",
-           branch_ref: "feat/board",
-           title: "Queued card",
-           task_type: "code_change",
-           priority: 10,
-           status: "queued",
-           updated_at: "2026-05-23T00:00:00Z"
-         },
-         %{
-           id: "wk-2",
-           repo_ref: "deepwatrcreatur/unified-nix-configuration",
-           branch_ref: "feat/deploy",
-           title: "Needs approval",
-           task_type: "deploy",
-           priority: 20,
-           status: "awaiting_human_input",
-           updated_at: "2026-05-23T00:05:00Z"
-         }
-       ]}
+        %{
+          id: "wk-1",
+          repo_ref: "deepwatrcreatur/agent-roundtable",
+          branch_ref: "feat/board",
+          source_ref: "round-1",
+          title: "Queued card",
+          task_type: "code_change",
+          priority: 10,
+          status: "queued",
+          assignee_ref: "codex-queue",
+          desired_outcome: %{"result" => "Queue remains visible"},
+          updated_at: "2026-05-23T00:00:00Z"
+        },
+        %{
+          id: "wk-2",
+          repo_ref: "deepwatrcreatur/unified-nix-configuration",
+          branch_ref: "feat/deploy",
+          source_ref: "round-2",
+          title: "Needs approval",
+          task_type: "deploy",
+          priority: 20,
+          status: "awaiting_human_input",
+          assignee_ref: "codex-review",
+          desired_outcome: %{"result" => "Promote after approval"},
+          updated_at: "2026-05-23T00:05:00Z"
+        }
+      ]}
     end
 
     def list_attempts(_repo_path, "wk-1", _opts), do: {:ok, []}
@@ -111,6 +117,10 @@ defmodule RoundtableWeb.BoardLiveTest do
     assert html =~ "Needs approval"
     assert html =~ "Approval required"
     assert html =~ "Selected card"
+    assert html =~ "Owner codex-review"
+    assert html =~ "Source round-2"
+    assert html =~ "Next signal"
+    assert html =~ "Promote after approval"
   end
 
   test "render can show a pre-filtered repo slice" do


### PR DESCRIPTION
## Summary
- add owner, source, freshness, and next-signal context to board cards
- expose desired outcome and richer card detail in the board sidebar
- extend board read-model and LiveView tests for the new public surface

## Testing
- nix develop . --command bash -lc 'cd roundtable && mix test test/roundtable/board_kanban_read_model_test.exs test/roundtable_web/board_live_test.exs test/roundtable/board_demo_seed_test.exs test/roundtable/mix_tasks/seed_board_demo_test.exs'