### PR TITLE
feat: link board cards to evidence surfaces

### DIFF
--- a/roundtable/lib/roundtable/board_kanban_read_model.ex
+++ b/roundtable/lib/roundtable/board_kanban_read_model.ex
@@ -6,7 +6,7 @@ defmodule Roundtable.BoardKanbanReadModel do
   attempt context without mutating or collapsing the underlying board lineage.
   """
 
-  alias Roundtable.Board
+  alias Roundtable.{Board, InvestorDemo}
 
   @queued_statuses ~w(queued retry_scheduled resumable)
   @active_statuses ~w(claimed running)
@@ -56,6 +56,7 @@ defmodule Roundtable.BoardKanbanReadModel do
     desired_outcome = desired_outcome_summary(item)
     next_signal = derive_next_signal(open_gate, recent_event, current_attempt, desired_outcome)
     freshness_state = derive_freshness_state(item, current_attempt, open_gate, runtime, recent_event, now)
+    evidence_links = derive_evidence_links(item)
 
     alert_refs =
       []
@@ -87,6 +88,7 @@ defmodule Roundtable.BoardKanbanReadModel do
       next_signal: next_signal,
       gate_prompt: open_gate && open_gate.prompt,
       freshness_state: freshness_state,
+      evidence_links: evidence_links,
       current_attempt_ref: current_attempt && current_attempt.id,
       attempt_number: current_attempt && current_attempt.attempt_number,
       attempt_status: current_attempt && current_attempt.status,
@@ -283,6 +285,62 @@ defmodule Roundtable.BoardKanbanReadModel do
       true ->
         nil
     end
+  end
+
+  defp derive_evidence_links(item) do
+    []
+    |> Kernel.++(surface_links(item))
+    |> Kernel.++(demo_links(Map.get(item, :repo_ref)))
+    |> Enum.uniq_by(& &1.href)
+  end
+
+  defp surface_links(item) do
+    input_payload = Map.get(item, :input_payload) || %{}
+
+    [surface_link(Map.get(input_payload, :route) || Map.get(input_payload, "route")),
+     surface_link(Map.get(input_payload, :surface) || Map.get(input_payload, "surface"))]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp surface_link(path) when is_binary(path) do
+    if String.starts_with?(path, "/") do
+      %{label: surface_label(path), href: path, kind: "surface"}
+    end
+  end
+
+  defp surface_link(_path), do: nil
+
+  defp surface_label("/forgejo-shell/reports"), do: "Open reports"
+  defp surface_label("/forgejo-shell"), do: "Open Forgejo shell"
+  defp surface_label("/board"), do: "Open board"
+  defp surface_label(path), do: "Open #{path}"
+
+  defp demo_links(nil), do: []
+
+  defp demo_links(repo_ref) do
+    public_demo_targets()
+    |> Enum.filter(fn target ->
+      repo_ref in [target.source_slug, target.import_slug]
+    end)
+    |> Enum.flat_map(fn target ->
+      [
+        %{label: "Open #{target.id} demo", href: "/forgejo-shell?demo=#{target.id}", kind: "demo"},
+        %{label: "Open #{target.id} report", href: "/forgejo-shell/reports#report-#{target.id}", kind: "report"}
+      ]
+    end)
+  end
+
+  defp public_demo_targets do
+    InvestorDemo.catalog()
+    |> Enum.map(fn summary ->
+      imported =
+        case InvestorDemo.import(summary.id) do
+          {:ok, demo} -> demo.imported_repo.slug
+          _ -> nil
+        end
+
+      %{id: summary.id, source_slug: summary.source_slug, import_slug: imported}
+    end)
   end
 
   defp build_badges(item, attempt, runtime_status, gate_state, lease_state, alert_refs) do

--- a/roundtable/lib/roundtable_web/live/board_live.ex
+++ b/roundtable/lib/roundtable_web/live/board_live.ex
@@ -155,6 +155,15 @@ defmodule RoundtableWeb.BoardLive do
                 <div :if={card.next_signal} style="color: #c9d1d9; font-size: 0.8rem; line-height: 1.4; margin-bottom: 0.55rem;">
                   Next signal: {card.next_signal}
                 </div>
+                <div :if={card.evidence_links != []} style="display: flex; gap: 0.45rem; flex-wrap: wrap; margin-bottom: 0.55rem;">
+                  <a
+                    :for={link <- Enum.take(card.evidence_links, 2)}
+                    href={link.href}
+                    style={evidence_link_style(link.kind)}
+                  >
+                    {link.label}
+                  </a>
+                </div>
                 <div style="display: flex; gap: 0.35rem; flex-wrap: wrap;">
                   <span :for={badge <- Enum.take(card.badge_refs, 4)} style={badge_style(badge)}>{badge}</span>
                 </div>
@@ -195,6 +204,15 @@ defmodule RoundtableWeb.BoardLive do
               <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase; margin-bottom: 0.4rem;">Desired outcome</div>
               <div style="background: rgba(13,17,23,0.86); border: 1px solid #30363d; border-radius: 10px; padding: 0.75rem; color: #c9d1d9; font-size: 0.84rem; line-height: 1.5;">
                 {@selected_card.desired_outcome}
+              </div>
+            </div>
+
+            <div :if={@selected_card.evidence_links != []} style="margin-bottom: 0.9rem;">
+              <div style="color: #58a6ff; font-size: 0.78rem; text-transform: uppercase; margin-bottom: 0.4rem;">Related evidence</div>
+              <div style="display: flex; gap: 0.45rem; flex-wrap: wrap;">
+                <a :for={link <- @selected_card.evidence_links} href={link.href} style={evidence_link_style(link.kind)}>
+                  {link.label}
+                </a>
               </div>
             </div>
 
@@ -387,6 +405,18 @@ defmodule RoundtableWeb.BoardLive do
 
   defp badge_style(_badge) do
     "display: inline-flex; align-items: center; background: rgba(88,166,255,0.1); border: 1px solid rgba(88,166,255,0.22); color: #8ec7ff; border-radius: 999px; padding: 0.18rem 0.45rem; font-size: 0.72rem;"
+  end
+
+  defp evidence_link_style("report") do
+    "display: inline-flex; align-items: center; text-decoration: none; background: rgba(210,153,34,0.12); border: 1px solid rgba(210,153,34,0.3); color: #f2cc60; border-radius: 999px; padding: 0.22rem 0.55rem; font-size: 0.74rem;"
+  end
+
+  defp evidence_link_style("demo") do
+    "display: inline-flex; align-items: center; text-decoration: none; background: rgba(88,166,255,0.12); border: 1px solid rgba(88,166,255,0.28); color: #8ec7ff; border-radius: 999px; padding: 0.22rem 0.55rem; font-size: 0.74rem;"
+  end
+
+  defp evidence_link_style(_kind) do
+    "display: inline-flex; align-items: center; text-decoration: none; background: rgba(63,185,80,0.12); border: 1px solid rgba(63,185,80,0.28); color: #7ee787; border-radius: 999px; padding: 0.22rem 0.55rem; font-size: 0.74rem;"
   end
 
   defp freshness_label("fresh"), do: "Fresh"

--- a/roundtable/test/roundtable/board_kanban_read_model_test.exs
+++ b/roundtable/test/roundtable/board_kanban_read_model_test.exs
@@ -14,6 +14,7 @@ defmodule Roundtable.BoardKanbanReadModelTest do
            source_ref: "round-queued",
            title: "Queued work",
            task_type: "code_change",
+           input_payload: %{"surface" => "/forgejo-shell"},
            priority: 10,
            status: "queued",
            assignee_ref: "codex-queued",
@@ -27,6 +28,7 @@ defmodule Roundtable.BoardKanbanReadModelTest do
            source_ref: "round-gated",
            title: "Needs approval",
            task_type: "deploy",
+           input_payload: %{"route" => "/forgejo-shell/reports"},
            priority: 20,
            status: "awaiting_human_input",
            assignee_ref: "codex-review",
@@ -40,6 +42,7 @@ defmodule Roundtable.BoardKanbanReadModelTest do
            source_ref: "round-running",
            title: "Runtime drift",
            task_type: "benchmark",
+           input_payload: %{"surface" => "/board"},
            priority: 30,
            status: "running",
            assignee_ref: "codex-bench",
@@ -48,13 +51,13 @@ defmodule Roundtable.BoardKanbanReadModelTest do
          },
          %{
            id: "wk-done",
-           repo_ref: "deepwatrcreatur/agent-roundtable",
+           repo_ref: "kubernetes/kubernetes",
            branch_ref: "feat/done",
            source_ref: "round-done",
            title: "Completed work",
            task_type: "review",
-           priority: 40,
-           status: "succeeded",
+            priority: 40,
+            status: "succeeded",
            assignee_ref: "codex-review",
            desired_outcome: %{"result" => "Validation passes"},
            updated_at: "2026-05-23T00:20:00Z"
@@ -177,14 +180,17 @@ defmodule Roundtable.BoardKanbanReadModelTest do
     assert cards["wk-gated"].owner_ref == "codex-review"
     assert cards["wk-gated"].next_signal == "Ship this?"
     assert cards["wk-gated"].freshness_state == "fresh"
+    assert Enum.any?(cards["wk-gated"].evidence_links, &(&1.href == "/forgejo-shell/reports"))
 
     assert cards["wk-running"].lane == "attention"
     assert "runtime_offline" in cards["wk-running"].alert_refs
     assert "lease:expired" in cards["wk-running"].badge_refs
     assert cards["wk-running"].next_signal == "Still running benchmarks"
     assert cards["wk-running"].freshness_state == "fresh"
+    assert Enum.any?(cards["wk-running"].evidence_links, &(&1.href == "/board"))
 
     assert cards["wk-done"].lane == "done"
+    assert Enum.any?(cards["wk-done"].evidence_links, &(&1.href == "/forgejo-shell?demo=kubernetes"))
     assert snapshot.counts["queued"] == 1
     assert snapshot.counts["gated"] == 1
     assert snapshot.counts["attention"] == 1

--- a/roundtable/test/roundtable_web/board_live_test.exs
+++ b/roundtable/test/roundtable_web/board_live_test.exs
@@ -18,6 +18,7 @@ defmodule RoundtableWeb.BoardLiveTest do
           source_ref: "round-1",
           title: "Queued card",
           task_type: "code_change",
+          input_payload: %{"surface" => "/forgejo-shell"},
           priority: 10,
           status: "queued",
           assignee_ref: "codex-queue",
@@ -26,11 +27,12 @@ defmodule RoundtableWeb.BoardLiveTest do
         },
         %{
           id: "wk-2",
-          repo_ref: "deepwatrcreatur/unified-nix-configuration",
+          repo_ref: "kubernetes/kubernetes",
           branch_ref: "feat/deploy",
           source_ref: "round-2",
           title: "Needs approval",
           task_type: "deploy",
+          input_payload: %{"route" => "/forgejo-shell/reports"},
           priority: 20,
           status: "awaiting_human_input",
           assignee_ref: "codex-review",
@@ -121,13 +123,16 @@ defmodule RoundtableWeb.BoardLiveTest do
     assert html =~ "Source round-2"
     assert html =~ "Next signal"
     assert html =~ "Promote after approval"
+    assert html =~ "/forgejo-shell/reports"
+    assert html =~ "/forgejo-shell?demo=kubernetes"
+    assert html =~ "Related evidence"
   end
 
   test "render can show a pre-filtered repo slice" do
     now = ~U[2026-05-23 01:00:00Z]
     {:ok, snapshot} = BoardKanbanReadModel.snapshot("/tmp/repo", board: FakeBoard, now: now)
 
-    cards = Enum.filter(snapshot.cards, &(&1.repo_ref == "deepwatrcreatur/unified-nix-configuration"))
+    cards = Enum.filter(snapshot.cards, &(&1.repo_ref == "kubernetes/kubernetes"))
     card_ids = MapSet.new(Enum.map(cards, & &1.work_item_id))
     lanes =
       Enum.map(snapshot.lanes, fn lane ->
@@ -140,7 +145,7 @@ defmodule RoundtableWeb.BoardLiveTest do
       %{
         __changed__: %{},
         repo_path: "/tmp/repo",
-        params: %{"repo" => "deepwatrcreatur/unified-nix-configuration"},
+        params: %{"repo" => "kubernetes/kubernetes"},
         filters: snapshot.filters,
         counts: snapshot.counts,
         snapshot_generated_at: snapshot.generated_at,


### PR DESCRIPTION
## Summary
- add board card links to related routes from canonical work item payloads
- add demo/report links when a card references a known public repo demo
- extend board read-model and LiveView tests for the linked evidence surface

## Testing
- nix develop . --command bash -lc 'cd roundtable && mix test test/roundtable/board_kanban_read_model_test.exs test/roundtable_web/board_live_test.exs'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cards now display associated evidence links sourced from input payloads and demo catalogs
  * Evidence links appear in the card view and dedicated "Related evidence" section in the sidebar
  * Links include distinct styling based on type and are automatically deduplicated

* **Tests**
  * Updated test fixtures to verify evidence link generation and display functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/agent-roundtable/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->