### PR TITLE
feat: declare board evidence metadata explicitly

### DIFF
--- a/roundtable/lib/roundtable/board_demo_seed.ex
+++ b/roundtable/lib/roundtable/board_demo_seed.ex
@@ -123,7 +123,13 @@ defmodule Roundtable.BoardDemoSeed do
         source_ref: "round-103",
         title: "Review board repo bootstrap on vaglio",
         task_type: "code_change",
-        input_payload: %{pr: 103, surface: "/board"},
+        input_payload: %{
+          pr: 103,
+          surface: "/board",
+          evidence_links: [
+            %{label: "Open board", href: "/board", kind: "surface"}
+          ]
+        },
         desired_outcome: %{result: "board route stays live after switch"},
         status: "running",
         priority: 10,
@@ -143,7 +149,11 @@ defmodule Roundtable.BoardDemoSeed do
         source_ref: "round-88",
         title: "Repair stalled public repo cache warm path",
         task_type: "ops_repair",
-        input_payload: %{surface: "/forgejo-shell", concern: "cache warm"},
+        input_payload: %{
+          surface: "/forgejo-shell",
+          concern: "cache warm",
+          public_demo_id: "kubernetes"
+        },
         desired_outcome: %{result: "all demo caches hot"},
         status: "running",
         priority: 20,
@@ -163,7 +173,13 @@ defmodule Roundtable.BoardDemoSeed do
         source_ref: "round-102",
         title: "Polish browseable board surface for public demos",
         task_type: "ui_polish",
-        input_payload: %{route: "/board", audience: "operators"},
+        input_payload: %{
+          route: "/board",
+          audience: "operators",
+          evidence_links: [
+            %{label: "Open reports", href: "/forgejo-shell/reports", kind: "report"}
+          ]
+        },
         desired_outcome: %{result: "legible live board"},
         status: "running",
         priority: 30,
@@ -183,7 +199,13 @@ defmodule Roundtable.BoardDemoSeed do
         source_ref: "round-95",
         title: "Thread Sourcegraph evidence into subtree briefs",
         task_type: "analysis",
-        input_payload: %{adapter: "sourcegraph", surface: "subtree_brief"},
+        input_payload: %{
+          adapter: "sourcegraph",
+          surface: "subtree_brief",
+          evidence_links: [
+            %{label: "Open Forgejo shell", href: "/forgejo-shell", kind: "surface"}
+          ]
+        },
         desired_outcome: %{result: "bounded semantic evidence in brief"},
         status: "queued",
         priority: 40,
@@ -203,7 +225,7 @@ defmodule Roundtable.BoardDemoSeed do
         source_ref: "round-89",
         title: "Ship shareable public repo reports page",
         task_type: "deployment",
-        input_payload: %{route: "/forgejo-shell/reports"},
+        input_payload: %{route: "/forgejo-shell/reports", public_demo_id: "kubernetes"},
         desired_outcome: %{result: "public reports route live"},
         status: "succeeded",
         priority: 50,
@@ -224,7 +246,12 @@ defmodule Roundtable.BoardDemoSeed do
         source_ref: "round-78",
         title: "Stabilize overlapping host deploy attempts",
         task_type: "ops_policy",
-        input_payload: %{resource: "host:vaglio"},
+        input_payload: %{
+          resource: "host:vaglio",
+          evidence_links: [
+            %{label: "Open board", href: "/board", kind: "surface"}
+          ]
+        },
         desired_outcome: %{result: "single-writer deploy policy"},
         status: "failed",
         priority: 60,

--- a/roundtable/lib/roundtable/board_kanban_read_model.ex
+++ b/roundtable/lib/roundtable/board_kanban_read_model.ex
@@ -6,7 +6,7 @@ defmodule Roundtable.BoardKanbanReadModel do
   attempt context without mutating or collapsing the underlying board lineage.
   """
 
-  alias Roundtable.{Board, InvestorDemo}
+  alias Roundtable.Board
 
   @queued_statuses ~w(queued retry_scheduled resumable)
   @active_statuses ~w(claimed running)
@@ -290,7 +290,7 @@ defmodule Roundtable.BoardKanbanReadModel do
   defp derive_evidence_links(item) do
     []
     |> Kernel.++(surface_links(item))
-    |> Kernel.++(demo_links(Map.get(item, :repo_ref)))
+    |> Kernel.++(declared_evidence_links(item))
     |> Enum.uniq_by(& &1.href)
   end
 
@@ -315,32 +315,55 @@ defmodule Roundtable.BoardKanbanReadModel do
   defp surface_label("/board"), do: "Open board"
   defp surface_label(path), do: "Open #{path}"
 
-  defp demo_links(nil), do: []
+  defp declared_evidence_links(item) do
+    input_payload = Map.get(item, :input_payload) || %{}
 
-  defp demo_links(repo_ref) do
-    public_demo_targets()
-    |> Enum.filter(fn target ->
-      repo_ref in [target.source_slug, target.import_slug]
-    end)
-    |> Enum.flat_map(fn target ->
-      [
-        %{label: "Open #{target.id} demo", href: "/forgejo-shell?demo=#{target.id}", kind: "demo"},
-        %{label: "Open #{target.id} report", href: "/forgejo-shell/reports#report-#{target.id}", kind: "report"}
-      ]
-    end)
+    explicit_links =
+      Map.get(input_payload, :evidence_links) ||
+        Map.get(input_payload, "evidence_links") ||
+        []
+
+    public_demo_id =
+      Map.get(input_payload, :public_demo_id) ||
+        Map.get(input_payload, "public_demo_id")
+
+    explicit_links(explicit_links) ++ public_demo_links(public_demo_id)
   end
 
-  defp public_demo_targets do
-    InvestorDemo.catalog()
-    |> Enum.map(fn summary ->
-      imported =
-        case InvestorDemo.import(summary.id) do
-          {:ok, demo} -> demo.imported_repo.slug
-          _ -> nil
-        end
+  defp explicit_links(links) when is_list(links) do
+    links
+    |> Enum.map(&normalize_explicit_link/1)
+    |> Enum.reject(&is_nil/1)
+  end
 
-      %{id: summary.id, source_slug: summary.source_slug, import_slug: imported}
-    end)
+  defp explicit_links(_links), do: []
+
+  defp normalize_explicit_link(%{href: href} = link) when is_binary(href) do
+    %{
+      label: Map.get(link, :label) || "Open evidence",
+      href: href,
+      kind: Map.get(link, :kind) || "evidence"
+    }
+  end
+
+  defp normalize_explicit_link(%{"href" => href} = link) when is_binary(href) do
+    %{
+      label: Map.get(link, "label") || "Open evidence",
+      href: href,
+      kind: Map.get(link, "kind") || "evidence"
+    }
+  end
+
+  defp normalize_explicit_link(_link), do: nil
+
+  defp public_demo_links(nil), do: []
+  defp public_demo_links(""), do: []
+
+  defp public_demo_links(demo_id) when is_binary(demo_id) do
+    [
+      %{label: "Open #{demo_id} demo", href: "/forgejo-shell?demo=#{demo_id}", kind: "demo"},
+      %{label: "Open #{demo_id} report", href: "/forgejo-shell/reports#report-#{demo_id}", kind: "report"}
+    ]
   end
 
   defp build_badges(item, attempt, runtime_status, gate_state, lease_state, alert_refs) do

--- a/roundtable/test/roundtable/board_kanban_read_model_test.exs
+++ b/roundtable/test/roundtable/board_kanban_read_model_test.exs
@@ -14,7 +14,12 @@ defmodule Roundtable.BoardKanbanReadModelTest do
            source_ref: "round-queued",
            title: "Queued work",
            task_type: "code_change",
-           input_payload: %{"surface" => "/forgejo-shell"},
+           input_payload: %{
+             "surface" => "/forgejo-shell",
+             "evidence_links" => [
+               %{"label" => "Open queued evidence", "href" => "/board", "kind" => "surface"}
+             ]
+           },
            priority: 10,
            status: "queued",
            assignee_ref: "codex-queued",
@@ -28,7 +33,7 @@ defmodule Roundtable.BoardKanbanReadModelTest do
            source_ref: "round-gated",
            title: "Needs approval",
            task_type: "deploy",
-           input_payload: %{"route" => "/forgejo-shell/reports"},
+           input_payload: %{"route" => "/forgejo-shell/reports", "public_demo_id" => "forgejo"},
            priority: 20,
            status: "awaiting_human_input",
            assignee_ref: "codex-review",
@@ -56,8 +61,9 @@ defmodule Roundtable.BoardKanbanReadModelTest do
            source_ref: "round-done",
            title: "Completed work",
            task_type: "review",
-            priority: 40,
-            status: "succeeded",
+           input_payload: %{"public_demo_id" => "kubernetes"},
+           priority: 40,
+           status: "succeeded",
            assignee_ref: "codex-review",
            desired_outcome: %{"result" => "Validation passes"},
            updated_at: "2026-05-23T00:20:00Z"
@@ -181,6 +187,7 @@ defmodule Roundtable.BoardKanbanReadModelTest do
     assert cards["wk-gated"].next_signal == "Ship this?"
     assert cards["wk-gated"].freshness_state == "fresh"
     assert Enum.any?(cards["wk-gated"].evidence_links, &(&1.href == "/forgejo-shell/reports"))
+    assert Enum.any?(cards["wk-gated"].evidence_links, &(&1.href == "/forgejo-shell?demo=forgejo"))
 
     assert cards["wk-running"].lane == "attention"
     assert "runtime_offline" in cards["wk-running"].alert_refs

--- a/roundtable/test/roundtable_web/board_live_test.exs
+++ b/roundtable/test/roundtable_web/board_live_test.exs
@@ -18,7 +18,12 @@ defmodule RoundtableWeb.BoardLiveTest do
           source_ref: "round-1",
           title: "Queued card",
           task_type: "code_change",
-          input_payload: %{"surface" => "/forgejo-shell"},
+          input_payload: %{
+            "surface" => "/forgejo-shell",
+            "evidence_links" => [
+              %{"label" => "Open board evidence", "href" => "/board", "kind" => "surface"}
+            ]
+          },
           priority: 10,
           status: "queued",
           assignee_ref: "codex-queue",
@@ -27,12 +32,12 @@ defmodule RoundtableWeb.BoardLiveTest do
         },
         %{
           id: "wk-2",
-          repo_ref: "kubernetes/kubernetes",
+          repo_ref: "deepwatrcreatur/agent-roundtable",
           branch_ref: "feat/deploy",
           source_ref: "round-2",
           title: "Needs approval",
           task_type: "deploy",
-          input_payload: %{"route" => "/forgejo-shell/reports"},
+          input_payload: %{"route" => "/forgejo-shell/reports", "public_demo_id" => "kubernetes"},
           priority: 20,
           status: "awaiting_human_input",
           assignee_ref: "codex-review",
@@ -132,7 +137,7 @@ defmodule RoundtableWeb.BoardLiveTest do
     now = ~U[2026-05-23 01:00:00Z]
     {:ok, snapshot} = BoardKanbanReadModel.snapshot("/tmp/repo", board: FakeBoard, now: now)
 
-    cards = Enum.filter(snapshot.cards, &(&1.repo_ref == "kubernetes/kubernetes"))
+    cards = Enum.filter(snapshot.cards, &(&1.work_item_id == "wk-2"))
     card_ids = MapSet.new(Enum.map(cards, & &1.work_item_id))
     lanes =
       Enum.map(snapshot.lanes, fn lane ->
@@ -145,7 +150,7 @@ defmodule RoundtableWeb.BoardLiveTest do
       %{
         __changed__: %{},
         repo_path: "/tmp/repo",
-        params: %{"repo" => "kubernetes/kubernetes"},
+        params: %{"repo" => "deepwatrcreatur/agent-roundtable"},
         filters: snapshot.filters,
         counts: snapshot.counts,
         snapshot_generated_at: snapshot.generated_at,


### PR DESCRIPTION
## Summary
- replace repo-name heuristics for board evidence links with explicit payload metadata
- seed the board demo with declared evidence links and public demo ids
- extend board read-model and LiveView tests around the explicit contract

## Testing
- nix develop . --command bash -lc 'cd roundtable && mix test test/roundtable/board_kanban_read_model_test.exs test/roundtable_web/board_live_test.exs test/roundtable/board_demo_seed_test.exs test/roundtable/mix_tasks/seed_board_demo_test.exs'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Work items now support explicit evidence links and public demo identifiers in their configuration, enabling richer metadata for each item.

* **Improvements**
  - Evidence links and demo/report references now derive from work item configuration, providing clearer control over associated resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/agent-roundtable/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->