### PR TITLE
docs: archive rounds on collisions and hosted control plane

### DIFF
--- a/docs/design/ORCHESTRATION_GUIDE.md
+++ b/docs/design/ORCHESTRATION_GUIDE.md
@@ -395,8 +395,8 @@ Notes:
 
 - this is an enrichment seat, not part of the mandatory serious quorum
 - save its output separately just like the primary seats
-- if a specific model fails, try another listed OpenCode seat once rather than
-  pretending the enrichment voice was never requested
+- if a specific model fails, try a different model from the discovery list once
+  rather than pretending the enrichment voice was never requested
 - if the command returns only startup noise, inspect the saved file before
   deciding whether the seat failed
 
@@ -417,6 +417,12 @@ That means writing a real independent position answering the same prompt:
 - what Copilot disagrees with
 - what Copilot would surface as the main failure mode
 - a satisfaction marker
+
+Valid markers are defined in `AGENTS.md` for this repo:
+
+- `[satisfied]`
+- `[satisfied-conditional: X]`
+- `[needs more evidence: X]`
 
 ## 7. Interpreting outputs
 

--- a/docs/design/ORCHESTRATION_GUIDE.md
+++ b/docs/design/ORCHESTRATION_GUIDE.md
@@ -174,6 +174,19 @@ also valid here and has been successfully recovered in-session using:
 If you think a round would benefit from one extra experimental voice, check
 whether the local OpenCode/free-model path is actually usable before launch.
 
+Practical preflight in this environment:
+
+```bash
+opencode models
+```
+
+This prints the locally available provider/model IDs. In recent runs it exposed
+free or cheap enrichment candidates such as:
+
+- `opencode/nemotron-3-super-free`
+- `opencode/deepseek-v4-flash-free`
+- `opencode/big-pickle`
+
 Typical reasons to add it:
 
 - the topic is broad and would benefit from one more independent angle
@@ -191,6 +204,8 @@ So the rule is:
 
 - use them opportunistically when they enrich the round
 - but never count them as evidence that the main requested roster was satisfied
+- and if OpenCode itself fails, record that failure as enrichment-seat
+  unavailability rather than smoothing it over
 
 ### 4.3 Preflight failure policy
 
@@ -358,7 +373,40 @@ Operational lesson:
 - recover the seat honestly, then amend the round note rather than leaving a
   stale “DeepSeek unavailable” statement in the durable record
 
-## 6.4 Copilot
+## 6.4 Optional enrichment seat: OpenCode / free models
+
+Use the real CLI when you add this seat.
+
+Recommended discovery step:
+
+```bash
+opencode models
+```
+
+Recommended one-shot run pattern:
+
+```bash
+PROMPT="$(cat /tmp/round_prompt.txt)"
+opencode run -m opencode/nemotron-3-super-free "$PROMPT" \
+  > /tmp/opencode_round.txt
+```
+
+Notes:
+
+- this is an enrichment seat, not part of the mandatory serious quorum
+- save its output separately just like the primary seats
+- if a specific model fails, try another listed OpenCode seat once rather than
+  pretending the enrichment voice was never requested
+- if the command returns only startup noise, inspect the saved file before
+  deciding whether the seat failed
+
+If the round topic explicitly evaluates harnesses, free-model access, or cheap
+extra dissent, record the seat concretely, for example:
+
+- `OpenCode free-model seat: substantive via opencode/nemotron-3-super-free`
+- `OpenCode free-model seat: unavailable after model/provider failure`
+
+## 6.5 Copilot
 
 Copilot should contribute an explicit fourth voice in the discussion leader's
 own synthesis process, not just summarize the others.
@@ -369,30 +417,6 @@ That means writing a real independent position answering the same prompt:
 - what Copilot disagrees with
 - what Copilot would surface as the main failure mode
 - a satisfaction marker
-
-## 6.5 Optional enrichment seat: OpenCode / free models
-
-If you add a free-model seat, do it intentionally rather than casually.
-
-Recommended use:
-
-- add **one** extra experimental seat
-- keep the same shared prompt
-- save the raw output separately
-- and record in the durable round note that it was an enrichment seat rather than
-  part of the mandatory core quorum
-
-Operational stance:
-
-- use it when it can make the round better
-- do not skip the chance reflexively
-- but do not let it blur the distinction between primary and experimental
-  evidence
-
-If the seat drifts, times out, or returns weak output, record that honestly and
-do not smooth it into the main consensus.
-
----
 
 ## 7. Interpreting outputs
 

--- a/docs/design/rounds/historical-synthesis.md
+++ b/docs/design/rounds/historical-synthesis.md
@@ -2,10 +2,11 @@
 
 Browse-oriented HTML companion: [`historical-synthesis.html`](./historical-synthesis.html).
 
-These notes record genuine follow-up rounds run with the actual CLI agents
-(`codex` and `gemini`). Claude was not used in these closes because the round
-owner explicitly allowed proceeding without Claude and Claude CLI availability
-was rate-limited during this session.
+These notes record genuine follow-up rounds run with real agent/tool seats.
+Some earlier closes in this file were archived during a session where the round
+owner explicitly allowed proceeding without Claude, but later entries record the
+exact roster actually used for each round, including Claude, DeepSeek API, and
+OpenCode enrichment seats where applicable.
 
 ## Round 45-46: Subject Tags & Multidimensional Discovery
 **Consensus:** Tags are first-class architecture, not cosmetic labels. For v1,
@@ -1016,12 +1017,31 @@ bulletin board / daemon orchestration layer, not in prose docs alone.
 ## Round 126: Elixir Is Plausible for `router-clat`, but the Contract Must Freeze Before the Boundary Does
 **Consensus:** The panel converged that Elixir is a credible fit for the
  `router-clat` control plane, and that the system should not become
- Tayga-shaped: the repo needs a backend-neutral control-plane contract,
- preserved-behavior testing from day one, and a clean split where
- `nix-router-optimized` remains the declarative host-integration layer. The
- real disagreement was timing: Codex and Copilot argued for building the Elixir
- path in-repo first and extracting only after parity and contract stability,
- while Gemini and DeepSeek argued that a separate repo now would force better
- product discipline. The maintained line was: freeze the behavior and testing
- contract first, then let repo structure follow proven boundaries rather than
- substitute for them.
+Tayga-shaped: the repo needs a backend-neutral control-plane contract,
+preserved-behavior testing from day one, and a clean split where
+`nix-router-optimized` remains the declarative host-integration layer. The
+real disagreement was timing: Codex and Copilot argued for building the Elixir
+path in-repo first and extracting only after parity and contract stability,
+while Gemini and DeepSeek argued that a separate repo now would force better
+product discipline. The maintained line was: freeze the behavior and testing
+contract first, then let repo structure follow proven boundaries rather than
+substitute for them.
+
+## Round 129: Local Harness Collisions vs Isolated Cloud Sandboxes
+**Consensus:** Shared-checkout collisions are fundamentally a workspace-isolation
+problem, not a local-harness problem. Better harnesses can improve invocation
+and ergonomics, but they do not make one mutable checkout safe for concurrent
+agent writes. The near-term operating model should be tiered: local worktrees
+for low-risk serial work, exe.dev VMs for collision-prone and deployment work,
+and Replit treated primarily as a structurally informative hosted-task reference
+rather than the default architecture.
+
+## Round 130: Hosted Control Plane Backend, Cloud Partners, and Durable Execution
+**Consensus:** The project should build an independent narrow control plane
+above multiple possible execution substrates, rather than collapsing into either
+Replit's hosted product shape or a single-substrate design. exe.dev is the more
+aligned first substrate partner because it looks like agent-ready infrastructure
+rather than a bundled coordination product. Durable-execution ideas from DBOS
+and Temporal are useful, but the first serious backend slice should still be a
+boring hosted claim/lease/attempt-lineage service rather than a heavyweight
+workflow engine.

--- a/docs/design/rounds/round-129-local-harness-collisions-vs-isolated-cloud-sandboxes.md
+++ b/docs/design/rounds/round-129-local-harness-collisions-vs-isolated-cloud-sandboxes.md
@@ -252,6 +252,8 @@ The maintained line is:
 
 ### Satisfaction marker
 
+[satisfied]
+
 This round is satisfied if:
 
 - the project stops treating shared local checkouts as the normal concurrent
@@ -259,4 +261,3 @@ This round is satisfied if:
 - exe.dev is trialed soon for `vaglio` and router-test work
 - and future work on harnesses stays scoped to invocation ergonomics rather than
   pretending to replace isolation
-

--- a/docs/design/rounds/round-129-local-harness-collisions-vs-isolated-cloud-sandboxes.md
+++ b/docs/design/rounds/round-129-local-harness-collisions-vs-isolated-cloud-sandboxes.md
@@ -1,0 +1,262 @@
+## Round 129 — Local Harness Collisions vs Isolated Cloud Sandboxes
+
+**Tags:** hygiene, workspaces, worktrees, opencode, replit, exe.dev, hosting  
+**Status:** Closed  
+**Voices used:** Codex CLI, Gemini CLI, Claude CLI, DeepSeek API, OpenCode free-model seat, Copilot synthesis  
+**Additional note:** Gemini initially failed on the full prompt inside its own
+router and was recovered with a shorter retry. OpenCode was used as an explicit
+enrichment seat via `opencode/nemotron-3-super-free`.
+
+### Round question
+
+The maintainer wanted a follow-up round on a recurring operational pain:
+
+- agents are still colliding in shared local checkouts
+- repeated worktree guidance has not made the collisions disappear
+- local cleanup still often turns into stash/replay/cherry-pick repair
+- and it is unclear whether better local harnesses will eventually solve this,
+  or whether the real answer is stronger sandboxing outside the shared machine
+
+The sharper decision questions were:
+
+- is this mainly a harness/defaults problem or a workspace-isolation problem
+- how much should the project expect from local harnesses such as OpenCode
+- whether Replit's isolated-task model is structurally closer to the right
+  answer
+- whether exe.dev is a credible near-term mitigation path for collision-prone
+  work such as `vaglio` deployment work or a router test VM
+- and what next-6-month operating model should replace today's repeated
+  instruction tightening
+
+### Grounding used in this round
+
+Relevant prior local context carried in:
+
+- **Round 108** — OpenCode is useful for experimental free-model access, but
+  harness choice by itself does not solve deeper coordination problems
+- **Round 116** — dirty-checkout failures persist because the shared checkout is
+  still the easiest writable default
+- **Round 117** — `jj` helps local mutation semantics but does not solve
+  claims, leases, authority, or promotion sequencing
+- **Round 119** — the future hosted control plane should stay narrow: claims,
+  leases, lineage, promotion gates, and visible human control
+
+Fresh external grounding carried in:
+
+- **Replit docs / changelog**
+  - active tasks run in isolated copies of a project
+  - parallel background task limits exist at the product tier level
+  - apply-back review and conflict handling are explicit product surfaces
+  - newer multi-artifact projects share backend/deployment/data while still
+    supporting parallel agent work
+- **exe.dev docs**
+  - `ssh exe.dev new` provisions fresh internet-reachable VMs
+  - Codex, Claude, and Shelley are preinstalled on new VMs
+  - persistent disks, HTTPS/IAM defaults, and repo-launch paths are built in
+  - Shelley can consume repo instructions such as `AGENTS.md`
+- **OpenCode**
+  - useful as a real enrichment path for free/cheap extra seats
+  - but historically not treated as the core serious quorum
+
+Important scope boundary carried into the round:
+
+- the question was **not** whether local harnesses are useless
+- it was whether they can ever be the main answer to shared-checkout collisions
+  in the face of repeated practical failure
+
+### Participation record
+
+What actually happened in this run:
+
+- **Codex CLI:** substantive
+- **Gemini CLI:** substantive after a shorter retry prompt
+- **Claude CLI:** substantive
+- **DeepSeek API:** substantive via direct HTTP API and local decrypted key
+- **OpenCode free-model seat:** substantive via `opencode/nemotron-3-super-free`
+- **Copilot:** substantive
+
+This round therefore had a **full substantive core roster plus one substantive
+enrichment seat**.
+
+### Voice summaries
+
+#### Codex CLI
+
+- Strongest on the claim that this is primarily a **workspace-isolation
+  problem**, not a harness-UX problem
+- Treated local harnesses as helpful for invocation, provider routing, and
+  worktree ergonomics, but not capable of fixing the default writable-path
+  problem
+- Preferred exe.dev as the near-term practical fit because it improves isolation
+  without forcing a Replit-shaped product shift
+- Recommended a three-tier near-term model:
+  - local worktrees for low-risk work
+  - exe.dev VMs for collision-prone/deployment work
+  - Replit only as a deliberate hosted-task pilot
+
+#### Gemini CLI
+
+- Strongest on the argument that shared-checkout collisions are fundamentally a
+  **mutable-filesystem chokepoint**
+- Most explicit that local harnesses cannot solve concurrent mutation of one
+  checkout because they do not own file locking, rollback, or durable leases
+- Treated Replit as structurally strong because its isolation is enforced rather
+  than advisory
+- Favored exe.dev for dedicated VM isolation and argued that stronger
+  instructions in shared repos eventually lead to state corruption and desperate
+  recovery actions
+
+#### Claude CLI
+
+- Strongest on the line that this is not a disobedience problem but a **missing
+  lease primitive** problem
+- Most explicit that OpenCode is still the same shared-checkout model with a
+  different frontend if it stays local
+- Framed Replit as stronger on bundled apply-back semantics and exe.dev as the
+  more natural fit for the project's current stack and deployment shape
+- Recommended a concrete tiered model:
+  - local worktrees for simple serial work
+  - exe.dev for `vaglio` and router-test VM work now
+  - Replit later only if its workflow constraints fit
+
+#### DeepSeek API
+
+- Strongest on the claim that the problem is **writable defaults plus lack of
+  isolation**, not a lack of smarter harness prompts
+- Most explicit that Replit and exe.dev are both sandbox providers rather than
+  the full coordination plane from Round 119
+- Favored exe.dev as an immediate practical mitigation while warning that it
+  does not solve claims, leases, or branch-level conflict by itself
+- Most forceful against the “just add stronger instructions” path, describing it
+  as an infinite regress of brittle local rules
+
+#### OpenCode free-model seat
+
+- Reinforced the same central line as the stronger seats:
+  local harnesses can reduce friction but cannot replace actual isolated working
+  copies
+- Framed Replit as lighter-weight hosted isolation and exe.dev as heavier but
+  more flexible VM isolation
+- Favored a split where local worktrees remain for low-risk work, exe.dev is
+  used for deployment/infrastructure tasks, and Replit is used where its
+  apply-back workflow is worth the platform dependence
+
+#### Copilot
+
+- I agreed with the convergence that repeated collisions are the result of the
+  wrong default execution boundary, not insufficient prose
+- My strongest synthesis point was that the project should stop asking shared
+  local repos to behave like a coordination system when they are merely mutable
+  filesystems
+- I also agreed that exe.dev is the most plausible immediate next step because
+  it improves isolation without requiring an early strategic commitment to a
+  Replit-shaped hosted product
+
+### First-pass convergence
+
+The substantive voices converged on the following points.
+
+1. **This is fundamentally a workspace-isolation problem.**
+   Better local harnesses can improve ergonomics, but not make one shared
+   mutable checkout safe for concurrent agent writes.
+
+2. **Local harnesses remain useful, but only at the invocation layer.**
+   They help with model access, provider routing, prompt discipline, and maybe
+   worktree bootstrap, but not with claims, leases, or collision-proof
+   mutation.
+
+3. **Replit demonstrates the structurally right isolation shape.**
+   Its isolated task copies and apply-back flow show what enforced separation
+   looks like when the host owns the workflow.
+
+4. **exe.dev is the best near-term mitigation for this project's highest-risk
+   work.**
+   It supplies real sandboxing now, fits the current stack better than Replit,
+   and can immediately absorb `vaglio`/router-test work without redesigning the
+   whole product.
+
+5. **Neither Replit nor exe.dev replaces the future control plane.**
+   They solve isolation at different layers, but not the claims/leases/lineage
+   coordination boundary that Round 119 described.
+
+6. **Trying to solve this mainly with stronger repo instructions is the wrong
+   direction.**
+   The repeated failure mode is procedural escalation around a bad writable
+   default.
+
+### Real disagreements that remained
+
+There was no major strategic disagreement, but there were real differences in
+timing and emphasis:
+
+- **Codex** was most explicit that Replit should be treated only as a pilot, not
+  the main system assumption
+- **Gemini** was most absolute that shared-checkout collision is a structural
+  problem and not realistically fixable by local-harness evolution
+- **Claude** was strongest on the lease/file-lock framing
+- **DeepSeek** was most emphatic that exe.dev is only half the answer because it
+  solves isolation without solving coordination
+
+These were differences in rollout posture, not direction.
+
+### Final synthesis
+
+The strongest answer from this round is:
+
+- **do not expect local harnesses to solve shared-checkout collisions as the
+  main path**
+- they can help around the edges, but the real fix is to stop treating one local
+  writable checkout as common agent space
+- use actual isolation for the risky work now
+- and keep the future control plane question separate from the immediate
+  sandboxing question
+
+The panel rejected two bad extremes:
+
+- **bad extreme A:** “keep refining instructions and local hygiene until the
+  collisions go away”
+- **bad extreme B:** “move everything to a hosted product immediately and let
+  that become the architecture”
+
+The maintained line is:
+
+- local worktrees remain useful for low-risk serial work
+- exe.dev should be used soon for the worst collision-prone and deployment
+  workloads
+- Replit is strategically informative because it proves the value of enforced
+  isolation plus apply-back flow
+- but the project should not confuse that with owning its own control plane
+
+### Recommended next-6-month operating model
+
+1. **Local worktrees by default for simple single-agent work.**
+   Keep them for bounded, serial code/docs work where the maintainer still wants
+   local speed.
+
+2. **exe.dev VMs by default for collision-prone and environmentful work.**
+   Start with:
+   - `vaglio`-adjacent deploy/test work
+   - router test VM work
+   - long-running or infrastructure-oriented agent tasks
+
+3. **Treat each exe.dev VM as one task sandbox.**
+   The durable artifact is the branch/PR/output, not the VM itself.
+
+4. **Evaluate Replit as a hosted-task UX reference, not yet the core stack.**
+   Use it to learn from isolated task copies and apply-back semantics, not as an
+   immediate architectural dependency.
+
+5. **Keep building toward the narrow hosted control plane.**
+   Isolation reduces collisions now, but claims/leases/lineage remain the next
+   real product layer.
+
+### Satisfaction marker
+
+This round is satisfied if:
+
+- the project stops treating shared local checkouts as the normal concurrent
+  write surface
+- exe.dev is trialed soon for `vaglio` and router-test work
+- and future work on harnesses stays scoped to invocation ergonomics rather than
+  pretending to replace isolation
+

--- a/docs/design/rounds/round-130-hosted-control-plane-backend-cloud-partners-and-durable-execution.md
+++ b/docs/design/rounds/round-130-hosted-control-plane-backend-cloud-partners-and-durable-execution.md
@@ -1,0 +1,277 @@
+## Round 130 — Hosted Control Plane Backend, Cloud Partners, and Durable Execution
+
+**Tags:** product, hosting, control-plane, exe.dev, replit, dbos, temporal  
+**Status:** Closed  
+**Voices used:** Codex CLI, Gemini CLI, Claude CLI, DeepSeek API, OpenCode free-model seat, Copilot synthesis  
+**Additional note:** Gemini again required a shorter retry prompt before it
+returned a substantive seat. OpenCode was again used as a real enrichment seat
+via `opencode/nemotron-3-super-free`.
+
+### Round question
+
+The maintainer wanted a follow-up round on what the cloud/backend path should be
+if the project moves beyond local collision mitigation and starts building a
+real agent control plane.
+
+The concrete question bundle was:
+
+- should the future backend/control-plane story be built inside a Replit-like
+  hosted product shape
+- should exe.dev be treated as the likely execution-substrate partner while the
+  project owns the control plane itself
+- is exe.dev or Replit more strategically aligned for an eventual agent-control
+  product
+- how should durable execution systems such as DBOS or Temporal fit
+- and how should the project evolve from today's GitHub Issues + Dolt +
+  markdown work queues without overbuilding
+
+### Grounding used in this round
+
+Relevant prior local context carried in:
+
+- **Round 117** — the forge-native system should own a narrow coordination/trust
+  plane above Git/`jj`: claims, leases, attempt lineage, promotion boundaries,
+  and scoped authority
+- **Round 119** — the optional hosted control plane should be a small shared
+  coordination layer, not a giant orchestration platform
+- **Round 70** — orchestration borrowing is useful, but roundtable itself should
+  not collapse into a total workflow engine
+- **Round 129** — current local pain is real enough that isolated cloud
+  substrates are already relevant operationally
+
+Fresh external grounding carried in:
+
+- **Replit docs / product shape**
+  - shared task board
+  - isolated task copies
+  - shared backend/deployment/data across multi-artifact projects
+  - parallel execution under one hosted product surface
+- **exe.dev docs**
+  - fast internet VMs
+  - persistent disks
+  - HTTPS/IAM defaults
+  - GitHub integration
+  - preinstalled coding agents
+  - stronger evidence of agent-ready infrastructure than of a native control
+    plane
+- **DBOS docs**
+  - durable workflows resume after crashes
+  - workflow IDs can function as idempotency keys
+  - durable/background workflow handles and step-level structure are first-class
+- **Temporal docs**
+  - crash-proof execution for long-running workflows
+  - explicit resumption and durable workflow state are core product promises
+
+Important scope boundary carried into the round:
+
+- the goal was **not** to design a giant scheduler
+- it was to find the clearest product/backend boundary for an agent control
+  plane that stays aligned with prior rounds
+
+### Participation record
+
+What actually happened in this run:
+
+- **Codex CLI:** substantive
+- **Gemini CLI:** substantive after a shorter retry prompt
+- **Claude CLI:** substantive
+- **DeepSeek API:** substantive via direct HTTP API and local decrypted key
+- **OpenCode free-model seat:** substantive via `opencode/nemotron-3-super-free`
+- **Copilot:** substantive
+
+This round therefore had a **full substantive core roster plus one substantive
+enrichment seat**.
+
+### Voice summaries
+
+#### Codex CLI
+
+- Strongest on the recommendation to **build the control plane independently**
+  and keep it narrow
+- Treated exe.dev as strategically better aligned than Replit because it looks
+  more like agent-ready compute than an already-opinionated hosted workflow
+  product
+- Most explicit that the first serious slice should be durable
+  `WorkItem`/`Claim`/`Lease`/`Run`/`Promotion` objects with substrate adapters
+- Favored borrowing durable-execution ideas early but delaying any hard
+  commitment to a heavyweight workflow engine
+
+#### Gemini CLI
+
+- Strongest on the distinction between **unbundled compute** and a **walled
+  garden hosted product**
+- Favored exe.dev as the more strategically compatible substrate because it does
+  not collapse coordination logic into its own IDE/product layer
+- Most favorable to a DBOS-like philosophy over Temporal, especially because the
+  project already thinks in terms of durable state and lineage rather than a
+  giant orchestration console
+- Preferred a hot/cold state split:
+  - hosted control plane for active coordination
+  - repo-local artifacts for slower-changing work definition and history
+
+#### Claude CLI
+
+- Strongest on calling Replit a likely **competitor-shaped dependency** rather
+  than a clean substrate
+- Most explicit that exe.dev is the better substrate partner precisely because
+  it is thinner and less semantically invasive
+- Favored an independent control plane with multiple substrate targets as the
+  cleanest architecture boundary
+- Strongest against adopting Temporal or DBOS too early as product-shaping
+  dependencies
+
+#### DeepSeek API
+
+- Strongest on the line that both Replit and exe.dev should be treated as
+  **external execution substrates**
+- Most explicit that Replit's built-in coordination surfaces are attractive but
+  boundary-confusing for a project that wants to own the trust plane itself
+- Favored a strangler-fig migration:
+  first move attempt lineage and lease state into a hosted service, while
+  keeping work definitions and durable project artifacts repo-local
+- Most concrete that the first backend slice should be a hosted
+  attempt-lineage + lease service, likely targeting exe.dev first
+
+#### OpenCode free-model seat
+
+- Reinforced the same independent-control-plane boundary as the stronger seats
+- Favored exe.dev as the better substrate because it is less bundled with
+  coordination semantics than Replit
+- Strongest on keeping DBOS/Temporal out of the first slice and treating them as
+  optional later additions rather than immediate foundations
+
+#### Copilot
+
+- I agreed with the convergence that Replit is stronger today as a hosted
+  product, but exe.dev is more strategically aligned as a substrate if the
+  project wants to own the control plane
+- My strongest synthesis point was that the backend should first become a narrow
+  hosted claim/lease/lineage layer with substrate adapters, not a general
+  workflow system
+- I also agreed that DBOS/Temporal ideas are more valuable right now than a hard
+  dependency on either product
+
+### First-pass convergence
+
+The substantive voices converged on the following points.
+
+1. **The project should own an independent narrow control plane.**
+   The cleanest architecture is not Replit-as-everything or exe.dev-as-the-whole
+   product, but project-owned coordination logic above multiple possible
+   substrates.
+
+2. **exe.dev is the better-aligned substrate partner.**
+   It behaves more like agent-ready infrastructure and less like an already
+   opinionated hosted workflow product.
+
+3. **Replit is strategically informative but boundary-dangerous.**
+   Its product proves the value of isolated task copies and hosted coordination,
+   but that very strength makes it less suitable as the neutral substrate for a
+   project that wants to own the coordination layer.
+
+4. **DBOS/Temporal should not define the first serious slice.**
+   The round liked durable execution concepts such as idempotency, resumability,
+   and crash recovery, but did not favor adopting a full workflow platform
+   before the control-plane object model is proven.
+
+5. **The first migration target should be active coordination state.**
+   Claims, leases, heartbeats, attempt lineage, and promotion state are the
+   pieces that most want a single hosted source of truth.
+
+6. **Repo-local work definition should remain portable longer.**
+   Markdown queue files, durable discussion artifacts, and code/project history
+   should not be the first things absorbed into a hosted backend.
+
+### Real disagreements that remained
+
+There was no major strategic disagreement, but there were real differences in
+implementation taste:
+
+- **Codex** was most willing to define the first serious hosted object model in
+  concrete API terms immediately
+- **Gemini** was the most favorable to a DBOS-style philosophy once the project
+  is ready for more durability
+- **Claude** was most skeptical of taking on workflow-engine dependencies early
+- **DeepSeek** was strongest on the phased migration path from today's
+  GitHub/Dolt/markdown state
+
+These were differences in timing and mechanism, not direction.
+
+### Final synthesis
+
+The strongest answer from this round is:
+
+- **build the control plane independently**
+- keep it narrow around claims, leases, lineage, promotion, and scoped
+  authority
+- target multiple substrates
+- use exe.dev as the most plausible first execution substrate
+- and avoid letting Replit's stronger hosted product shape become the hidden
+  architecture of your own system
+
+The panel rejected two bad extremes:
+
+- **bad extreme A:** “just become a Replit plugin / workflow layer”
+- **bad extreme B:** “adopt a heavyweight durable workflow platform before the
+  control-plane boundary is even proven”
+
+The maintained line is:
+
+- repo-local and forge-local artifacts remain important
+- hosted backend state should first absorb the active coordination layer
+- durable execution ideas matter
+- but the first backend slice is still a boring coordination service, not a
+  full-blown orchestration engine
+
+### Recommended product/backend boundary
+
+#### Project-owned hosted control plane
+
+- work claims
+- expiring leases / heartbeats
+- attempt lineage / supersession
+- promotion boundaries
+- scoped agent authority
+- substrate adapter state
+- minimal operator inspection surface
+
+#### First execution substrate
+
+- exe.dev VMs as the initial agent-ready substrate adapter
+
+#### Strategic reference, not foundation
+
+- Replit as evidence that hosted isolated task copies and apply-back semantics
+  are product-valuable
+
+#### Deferred or optional later layer
+
+- DBOS/Temporal-class durable workflow engines, only if the narrow hosted
+  control plane proves it needs them
+
+### If only one serious backend slice ships next year
+
+The repeated strongest answer was:
+
+- **ship the hosted claim/lease/attempt-lineage service first**
+
+That slice should:
+
+- own active coordination truth
+- expose a simple API
+- sync with GitHub / forge state rather than replacing it
+- attach to substrate adapters such as exe.dev
+- and give operators a clean view of who owns what and which attempt is current
+
+### Satisfaction marker
+
+This round is satisfied if:
+
+- the project commits to the independent-control-plane boundary
+- exe.dev is treated as the first substrate partner rather than the whole
+  product
+- Replit is treated as a strategic reference point rather than an accidental
+  architecture dependency
+- and durable-execution dependencies stay deferred until the narrow hosted slice
+  proves real pressure for them
+

--- a/docs/design/rounds/round-130-hosted-control-plane-backend-cloud-partners-and-durable-execution.md
+++ b/docs/design/rounds/round-130-hosted-control-plane-backend-cloud-partners-and-durable-execution.md
@@ -265,6 +265,8 @@ That slice should:
 
 ### Satisfaction marker
 
+[satisfied]
+
 This round is satisfied if:
 
 - the project commits to the independent-control-plane boundary
@@ -274,4 +276,3 @@ This round is satisfied if:
   architecture dependency
 - and durable-execution dependencies stay deferred until the narrow hosted slice
   proves real pressure for them
-


### PR DESCRIPTION
## Summary
- archive Round 129 on shared-checkout collisions vs isolated cloud sandboxes
- archive Round 130 on hosted control-plane backend strategy, exe.dev vs Replit, and durable execution
- update the orchestration guide with concrete OpenCode enrichment-seat usage
- extend historical synthesis with both new rounds

## Notes
- both rounds used real seats from Codex, Claude, DeepSeek API, and OpenCode
- Gemini required shorter retry prompts but ultimately returned substantive seats
- this branch was cut from current ; the local working checkout had additional unmerged archive drift that was intentionally left untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Orchestration guide: added a practical preflight step for discovering local models, clarified optional enrichment-seat usage and failure recording, added one-shot run/save-output instructions, retry rules, and durable-round-note labeling examples; updated Copilot satisfaction-marker options.
  * Added Round 129 and Round 130 design writeups covering workspace-isolation, hosted control‑plane strategy, execution-substrate choices, and satisfaction criteria.
  * Clarified historical synthesis with explicit participant rosters and per-round summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/agent-roundtable/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->