### PR TITLE
docs(rounds): clarify file reservations boundary

### DIFF
--- a/docs/design/rounds/historical-synthesis.md
+++ b/docs/design/rounds/historical-synthesis.md
@@ -36,6 +36,11 @@ head. To prevent stale-success promotion, each private change must carry enough
 metadata for the orchestrator to detect causal and architectural overlap before
 full revalidation. Architecturally incompatible but locally valid changes go to
 arbitration rather than “first to the gate wins.”
+**Clarification:** A file reservation is a lightweight declaration that an
+agent intends to edit a file or file set, usually so other agents can avoid the
+same area. Later rounds 129 and 130 strengthened the line that reservations are
+useful coordination metadata, but not a substitute for isolated mutation spaces
+such as worktrees, sandboxes, or per-agent VMs.
 
 ## Round 49: Controversial Open Source Figures as Case Studies
 **Consensus:** Vaglio must not score people directly. It should score contested

--- a/docs/design/rounds/round-48-file-reservations-vs-git-worktrees.md
+++ b/docs/design/rounds/round-48-file-reservations-vs-git-worktrees.md
@@ -7,6 +7,11 @@
 
 ### First-pass convergence
 
+- **File reservations** in this context mean a lightweight coordination
+  mechanism where an agent declares intent to modify a file or file set before
+  editing it. The declaration can live in a queue system, database, lock file,
+  or orchestration service and is meant to signal "I am working here now" so
+  other agents can route around the same area.
 - `jj` does not remove the need for coordination; it changes reservations from
   correctness locks into scheduling / intent primitives.
 - Every agent should get a private ephemeral working copy (or the cheapest
@@ -69,5 +74,22 @@ Virtual worktrees are the right default, but only with:
 - promotion manifests
 - causal-overlap detection before expensive validation
 - an explicit arbitration lane for architectural conflict
+
+### Later-round clarification
+
+Rounds 129 and 130 did not reverse this position. They sharpened it.
+
+- file reservations are still useful for intent signaling, claims, leases, and
+  scheduling
+- file reservations are not the main safety boundary for concurrent edits in
+  one shared writable checkout
+- the real mutation boundary should still be a private worktree, sandbox, VM,
+  or other isolated execution space
+
+The updated interpretation is:
+
+- reservations help agents know who plans to touch what
+- isolated workspaces prevent those plans from turning into direct write
+  collisions
 
 `[satisfied]`


### PR DESCRIPTION
## Summary
- define what file reservations mean in Round 48
- clarify that later rounds 129 and 130 narrow reservations to advisory coordination rather than the main safety boundary
- mirror that clarification in the historical synthesis

## Testing
- not run (docs-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the definition and scope of file reservations as coordination metadata for agent scheduling, and reiterated that isolated workspaces (worktrees, sandboxes, or VMs) serve as the primary safety boundary for concurrent edits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/agent-roundtable/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->