### PR TITLE
docs: clarify direct-to-main round fast path

### DIFF
--- a/docs/design/ORCHESTRATION_GUIDE.md
+++ b/docs/design/ORCHESTRATION_GUIDE.md
@@ -510,6 +510,34 @@ Use this workflow:
 
 This avoids overwriting unrelated local documentation or implementation work.
 
+### 10.1 Default and exception
+
+The default policy is still:
+
+- publish rounds from a clean branch/worktree
+- then merge into `main`
+
+This repo should **not** assume that discussion rounds are safe to push directly
+to `main` just because they are prose. The common failure mode is not code bugs;
+it is archive drift or mixed local state:
+
+- wrong roster claims
+- missing satisfaction markers
+- overstated consensus
+- incorrect round numbering
+- or mixing the new writeup with unrelated local edits
+
+Direct-to-`main` is allowed only as an explicit fast path when **all** of the
+following are true:
+
+1. the maintainer explicitly asked for direct push to `main`
+2. the checkout is clean before the round archive edits begin
+3. the change is limited to the intended round archive files
+4. the leader verified roster accuracy, satisfaction markers, and round
+   numbering before pushing
+
+If any of those are false, use the normal clean-branch publishing path.
+
 ---
 
 ## 11. Known pitfalls


### PR DESCRIPTION
## Summary
- keep clean branch/worktree publishing as the default for discussion rounds
- add an explicit direct-to-main exception only for clean, maintainer-requested fast paths
- document the archive-drift risks that make branches still useful even for prose rounds

## Testing
- not run (docs-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the orchestration guide with a new section clarifying publishing workflow procedures, distinguishing between the default safe approach and an explicit fast path for direct-to-main pushes, including required conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/agent-roundtable/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->