### PR TITLE
fix: auto-upgrade existing board schemas

### DIFF
--- a/roundtable/lib/roundtable/board.ex
+++ b/roundtable/lib/roundtable/board.ex
@@ -16,6 +16,14 @@ defmodule Roundtable.Board do
 
   alias Roundtable.Vcs.Dolt
 
+  @schema_repairs %{
+    "work_items" => [
+      %{column: "surface_route", ddl: "ALTER TABLE work_items ADD COLUMN surface_route TEXT;"},
+      %{column: "public_demo_id", ddl: "ALTER TABLE work_items ADD COLUMN public_demo_id VARCHAR(255);"},
+      %{column: "evidence_links_json", ddl: "ALTER TABLE work_items ADD COLUMN evidence_links_json TEXT;"}
+    ]
+  }
+
   @schema_files [
     Application.app_dir(
       :roundtable,
@@ -46,7 +54,12 @@ defmodule Roundtable.Board do
   def ensure_schema(repo_path, opts) do
     dolt = Keyword.get(opts, :dolt, Dolt)
     query_opts = Keyword.drop(opts, [:dolt])
-    dolt.query(schema_sql(), [repo_path: repo_path] ++ query_opts)
+
+    with {:ok, _} <- dolt.query(schema_sql(), [repo_path: repo_path] ++ query_opts),
+         {:ok, repairs} <- apply_schema_repairs(dolt, repo_path, query_opts),
+         {:ok, _} <- commit_schema_repairs(dolt, repo_path, repairs, opts) do
+      {:ok, %{repaired_columns: repairs}}
+    end
   end
 
   @spec create_work_item(String.t() | nil, map(), keyword()) :: :ok | {:error, term()}
@@ -244,6 +257,80 @@ defmodule Roundtable.Board do
            ) do
       :ok
     end
+  end
+
+  defp apply_schema_repairs(dolt, repo_path, query_opts) do
+    Enum.reduce_while(@schema_repairs, {:ok, []}, fn {table, repairs}, {:ok, repaired_columns} ->
+      with {:ok, existing_columns} <- table_columns(dolt, repo_path, table, query_opts),
+           {:ok, table_repairs} <-
+             apply_missing_table_repairs(
+               dolt,
+               repo_path,
+               existing_columns,
+               repairs,
+               query_opts
+             ) do
+        {:cont, {:ok, repaired_columns ++ table_repairs}}
+      else
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp table_columns(dolt, repo_path, table, query_opts) do
+    with {:ok, rows} <- dolt.query("DESCRIBE #{table};", [repo_path: repo_path] ++ query_opts) do
+      columns =
+        rows
+        |> Enum.map(&(Map.get(&1, "Field") || Map.get(&1, "field") || Map.get(&1, "COLUMN_NAME")))
+        |> Enum.reject(&is_nil/1)
+        |> MapSet.new()
+
+      {:ok, columns}
+    end
+  end
+
+  defp apply_missing_table_repairs(dolt, repo_path, existing_columns, repairs, query_opts) do
+    repairs
+    |> Enum.reject(&MapSet.member?(existing_columns, &1.column))
+    |> Enum.reduce_while({:ok, []}, fn repair, {:ok, applied_repairs} ->
+      case dolt.query(repair.ddl, [repo_path: repo_path] ++ query_opts) do
+        {:ok, _} ->
+          {:cont, {:ok, [repair.column | applied_repairs]}}
+
+        {:error, {:command_failed, _status, output}} ->
+          if duplicate_column_error?(output) do
+            {:cont, {:ok, applied_repairs}}
+          else
+            {:halt, {:error, {:schema_repair_failed, repair.column, output}}}
+          end
+
+        {:error, _} = error ->
+          {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, applied_repairs} -> {:ok, Enum.reverse(applied_repairs)}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp commit_schema_repairs(_dolt, _repo_path, [], _opts), do: {:ok, :no_repairs}
+
+  defp commit_schema_repairs(dolt, repo_path, repaired_columns, opts) do
+    query_opts = Keyword.drop(opts, [:dolt])
+    sign? = Keyword.get(opts, :sign?, false)
+    signing_key = Keyword.get(opts, :signing_key, System.get_env("ROUNDTABLE_BOARD_SIGNING_KEY"))
+
+    dolt.write_files(
+      %{
+        message: schema_repair_commit_message(repaired_columns),
+        branch: "main",
+        changes: [],
+        sign?: sign?,
+        signing_key: signing_key
+      },
+      [repo_path: repo_path] ++ query_opts
+    )
   end
 
   defp work_item_upsert_sql(attrs) do
@@ -601,6 +688,10 @@ defmodule Roundtable.Board do
     "#{message}\n\n[board-schema: durable-execution]"
   end
 
+  defp schema_repair_commit_message(repaired_columns) do
+    "fix(board): repair schema columns #{Enum.join(repaired_columns, ", ")}\n\n[board-schema: durable-execution]"
+  end
+
   defp now_iso8601 do
     DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
   end
@@ -610,4 +701,11 @@ defmodule Roundtable.Board do
     |> to_string()
     |> String.replace("'", "''")
   end
+
+  defp duplicate_column_error?(output) when is_binary(output) do
+    String.contains?(output, "Duplicate column name") ||
+      String.contains?(output, "already exists")
+  end
+
+  defp duplicate_column_error?(_output), do: false
 end

--- a/roundtable/test/roundtable/board_test.exs
+++ b/roundtable/test/roundtable/board_test.exs
@@ -3,11 +3,80 @@ defmodule Roundtable.BoardTest do
 
   alias Roundtable.Board
 
+  @work_item_columns [
+    "id",
+    "repo_ref",
+    "branch_ref",
+    "source_ref",
+    "title",
+    "task_type",
+    "input_payload",
+    "surface_route",
+    "public_demo_id",
+    "evidence_links_json",
+    "desired_outcome",
+    "status",
+    "priority",
+    "assignee_type",
+    "assignee_ref",
+    "workflow_ref",
+    "retry_policy",
+    "timeout_policy",
+    "hitl_policy",
+    "created_at",
+    "updated_at",
+    "closed_at"
+  ]
+
+  @legacy_work_item_columns @work_item_columns --
+                              ["surface_route", "public_demo_id", "evidence_links_json"]
+
   defmodule FakeDolt do
+    @work_item_columns [
+      "id",
+      "repo_ref",
+      "branch_ref",
+      "source_ref",
+      "title",
+      "task_type",
+      "input_payload",
+      "surface_route",
+      "public_demo_id",
+      "evidence_links_json",
+      "desired_outcome",
+      "status",
+      "priority",
+      "assignee_type",
+      "assignee_ref",
+      "workflow_ref",
+      "retry_policy",
+      "timeout_policy",
+      "hitl_policy",
+      "created_at",
+      "updated_at",
+      "closed_at"
+    ]
+
     def query(sql, _opts) do
       send(self(), {:query, sql})
 
       cond do
+        String.contains?(sql, "DESCRIBE work_items") ->
+          columns = Process.get(:work_item_columns, @work_item_columns)
+          {:ok, Enum.map(columns, &%{"Field" => &1})}
+
+        String.contains?(sql, "ALTER TABLE work_items ADD COLUMN surface_route") ->
+          add_work_item_column("surface_route")
+          {:ok, []}
+
+        String.contains?(sql, "ALTER TABLE work_items ADD COLUMN public_demo_id") ->
+          add_work_item_column("public_demo_id")
+          {:ok, []}
+
+        String.contains?(sql, "ALTER TABLE work_items ADD COLUMN evidence_links_json") ->
+          add_work_item_column("evidence_links_json")
+          {:ok, []}
+
         String.contains?(sql, "SELECT id, repo_ref") ->
           {:ok,
            [
@@ -129,6 +198,11 @@ defmodule Roundtable.BoardTest do
       send(self(), {:commit, params})
       {:ok, %{commit_id: "abc123", branch: "main"}}
     end
+
+    defp add_work_item_column(column) do
+      columns = Process.get(:work_item_columns, @work_item_columns)
+      Process.put(:work_item_columns, Enum.uniq(columns ++ [column]))
+    end
   end
 
   test "schema SQL defines all board tables" do
@@ -172,6 +246,9 @@ defmodule Roundtable.BoardTest do
     assert_received {:query, schema_sql}
     assert schema_sql =~ "CREATE TABLE IF NOT EXISTS work_items"
 
+    assert_received {:query, describe_sql}
+    assert describe_sql =~ "DESCRIBE work_items"
+
     assert_received {:query, insert_sql}
     assert insert_sql =~ "REPLACE INTO work_items"
     assert insert_sql =~ "'wk-1'"
@@ -184,6 +261,33 @@ defmodule Roundtable.BoardTest do
     assert_received {:commit, commit}
     assert commit.message =~ "create work item wk-1"
     refute commit.sign?
+  end
+
+  test "ensure_schema repairs legacy work item columns and commits the schema upgrade" do
+    Process.put(:work_item_columns, @legacy_work_item_columns)
+
+    assert {:ok, %{repaired_columns: repaired_columns}} =
+             Board.ensure_schema("/tmp/repo", dolt: FakeDolt)
+
+    assert repaired_columns == ["surface_route", "public_demo_id", "evidence_links_json"]
+
+    assert_received {:query, schema_sql}
+    assert schema_sql =~ "CREATE TABLE IF NOT EXISTS work_items"
+
+    assert_received {:query, describe_sql}
+    assert describe_sql =~ "DESCRIBE work_items"
+
+    assert_received {:query, alter_surface_sql}
+    assert alter_surface_sql =~ "ALTER TABLE work_items ADD COLUMN surface_route"
+
+    assert_received {:query, alter_demo_sql}
+    assert alter_demo_sql =~ "ALTER TABLE work_items ADD COLUMN public_demo_id"
+
+    assert_received {:query, alter_evidence_sql}
+    assert alter_evidence_sql =~ "ALTER TABLE work_items ADD COLUMN evidence_links_json"
+
+    assert_received {:commit, schema_commit}
+    assert schema_commit.message =~ "repair schema columns surface_route, public_demo_id, evidence_links_json"
   end
 
   test "append_attempt and open_human_gate preserve retry lineage and structured gates" do
@@ -205,6 +309,9 @@ defmodule Roundtable.BoardTest do
 
     assert_received {:query, attempt_schema_sql}
     assert attempt_schema_sql =~ "CREATE TABLE IF NOT EXISTS work_attempts"
+
+    assert_received {:query, describe_attempt_schema_sql}
+    assert describe_attempt_schema_sql =~ "DESCRIBE work_items"
 
     assert_received {:query, attempt_sql}
     assert attempt_sql =~ "REPLACE INTO work_attempts"
@@ -231,6 +338,9 @@ defmodule Roundtable.BoardTest do
 
     assert_received {:query, gate_schema_sql}
     assert gate_schema_sql =~ "CREATE TABLE IF NOT EXISTS human_gates"
+
+    assert_received {:query, describe_gate_schema_sql}
+    assert describe_gate_schema_sql =~ "DESCRIBE work_items"
 
     assert_received {:query, gate_sql}
     assert gate_sql =~ "REPLACE INTO human_gates"
@@ -259,6 +369,9 @@ defmodule Roundtable.BoardTest do
 
     assert_received {:query, heartbeat_schema_sql}
     assert heartbeat_schema_sql =~ "CREATE TABLE IF NOT EXISTS runtime_heartbeats"
+
+    assert_received {:query, describe_heartbeat_schema_sql}
+    assert describe_heartbeat_schema_sql =~ "DESCRIBE work_items"
 
     assert_received {:query, heartbeat_sql}
     assert heartbeat_sql =~ "REPLACE INTO runtime_heartbeats"
@@ -289,6 +402,8 @@ defmodule Roundtable.BoardTest do
     assert item.id == "wk-1"
     assert_received {:query, get_item_schema_sql}
     assert get_item_schema_sql =~ "CREATE TABLE IF NOT EXISTS work_items"
+    assert_received {:query, get_item_describe_sql}
+    assert get_item_describe_sql =~ "DESCRIBE work_items"
     assert_received {:query, get_item_sql}
     assert get_item_sql =~ "FROM work_items"
 
@@ -296,6 +411,8 @@ defmodule Roundtable.BoardTest do
     assert attempt.id == "att-1"
     assert_received {:query, get_attempt_schema_sql}
     assert get_attempt_schema_sql =~ "CREATE TABLE IF NOT EXISTS work_attempts"
+    assert_received {:query, get_attempt_describe_sql}
+    assert get_attempt_describe_sql =~ "DESCRIBE work_items"
     assert_received {:query, get_attempt_sql}
     assert get_attempt_sql =~ "FROM work_attempts"
 
@@ -315,6 +432,9 @@ defmodule Roundtable.BoardTest do
 
     assert_received {:query, schema_sql}
     assert schema_sql =~ "CREATE TABLE IF NOT EXISTS work_attempt_events"
+
+    assert_received {:query, describe_event_schema_sql}
+    assert describe_event_schema_sql =~ "DESCRIBE work_items"
 
     assert_received {:query, event_sql}
 


### PR DESCRIPTION
## Summary
- inspect existing Dolt board schemas during `ensure_schema/2`
- apply missing `ALTER TABLE` repairs for legacy `work_items` columns and commit the upgrade once
- add a regression test covering the legacy board repo path

## Testing
- nix develop . --command bash -lc 'cd roundtable && mix test test/roundtable/board_test.exs test/roundtable/board_kanban_read_model_test.exs test/roundtable_web/board_live_test.exs test/roundtable/board_demo_seed_test.exs test/roundtable/mix_tasks/seed_board_demo_test.exs'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic schema repair: the system now detects and applies missing database column repairs automatically during standard operations.
  * Schema repair commits support optional signing parameters for enhanced security.

* **Tests**
  * Extended test coverage for schema operations and repair workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/agent-roundtable/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->