### PR TITLE
docs: define embedded design history model

### DIFF
--- a/docs/design/EMBEDDED_DESIGN_HISTORY_MODEL.md
+++ b/docs/design/EMBEDDED_DESIGN_HISTORY_MODEL.md
@@ -1,0 +1,212 @@
+# Embedded Design History Model
+
+**Status:** Drafted from Rounds 56, 63, and 89
+**Purpose:** Define the now-maintained embedded design-history model after the
+historical design corpus was brought into `agent-roundtable` and later split
+into canonical markdown archives, derived query layers, and operational board
+linkage.
+
+---
+
+## 1. Boundary
+
+This note answers a narrow question:
+
+> What does it mean for design history to be "embedded" in the main repo without
+> collapsing archives, local code-context memory, and board state into one
+> undifferentiated layer?
+
+The embedded model owns:
+
+- canonical round/design markdown archives inside the main repo
+- bounded near-code memory pointers and sidecars
+- derived query/index layers built from canonical markdown
+- board/task linkage to relevant design memory
+
+It must **not** mean:
+
+- the board becoming the canonical archive of rationale
+- code comments replacing deliberative history
+- derived indices becoming more authoritative than markdown
+
+---
+
+## 2. What item 56 originally meant
+
+The original item was about ending the split where:
+
+- `agent-roundtable-design` held design history elsewhere
+- `agent-roundtable` held product code and execution surfaces here
+
+That merge has effectively already happened:
+
+- the repo now contains `docs/design/rounds/`
+- `docs/design/ACTIVE_DISCUSSION.md`
+- `docs/design/DECISION.md`
+- `docs/design/historical-synthesis`-style long-horizon memory
+
+So the remaining design question is no longer "should the history be imported?"
+
+It is:
+
+- how should the embedded history be structured and queried now that it lives
+  here?
+
+---
+
+## 3. Canonical split
+
+The maintained answer is a hybrid model.
+
+### 3.1 Canonical markdown
+
+Markdown inside `docs/design/` remains the source of truth for:
+
+- round rationale
+- disagreement and synthesis
+- satisfaction / closure markers
+- long-form audit history
+
+This is the durable deliberative archive.
+
+### 3.2 Derived query/index layers
+
+Derived layers exist for:
+
+- round lookup
+- tag search
+- related-round traversal
+- other machine-friendly retrieval
+
+These are derived from markdown and must lose to markdown if they diverge.
+
+### 3.3 Near-code / subtree memory
+
+The embedded model also supports bounded local memory closer to code, such as:
+
+- `jj`-visible intent pointers
+- subtree sidecars
+- selective local annotations
+
+These are projections or localized entry points, not replacements for the full
+archive.
+
+### 3.4 Board/task linkage
+
+The board should link to relevant design-memory records for active work, but the
+board is not the archive of design truth.
+
+---
+
+## 4. Placement rules
+
+### 4.1 Keep in round archives
+
+- alternatives considered
+- trade-offs
+- disagreement
+- final synthesis and closure
+- long-form legitimacy/audit review
+
+### 4.2 Keep in derived/query layers
+
+- round metadata summaries
+- tag and relationship indexes
+- browse/search-oriented entry points
+
+### 4.3 Keep near code
+
+- bounded invariants
+- local design-intent pointers
+- path/subtree-specific summaries
+- supersedable local memory projections
+
+### 4.4 Keep in the board
+
+- execution linkage
+- current work/attempt association
+- human gate state
+- references to relevant design-memory artifacts
+
+This is the clean operational separation item 56 needed to mature into.
+
+---
+
+## 5. Why "embedded" does not mean "everything inline"
+
+The project rejected two bad extremes:
+
+- **archive-only** memory that is too far away from active edits
+- **everything-inline** memory where code comments, board rows, and local notes
+  compete as parallel truths
+
+The maintained line is:
+
+- one canonical archive layer
+- bounded local projections
+- derived query surfaces
+- explicit supersession/lifecycle
+
+That is what makes the embedded model useful instead of noisy.
+
+---
+
+## 6. Supersession and lifecycle
+
+Embedded design memory must support lifecycle from the start.
+
+Every projection or local memory surface should be able to express:
+
+- current
+- stale
+- superseded-by
+
+Otherwise the embedded layer becomes cargo-cult residue.
+
+This is one of the strongest conclusions from Round 63 and remains the
+guardrail for any future near-code design memory work.
+
+---
+
+## 7. Relationship to later work
+
+Item 56 is now concretely realized by later pieces:
+
+| Concern | Current landing place |
+|---|---|
+| Design history lives in the main repo | `docs/design/rounds/`, `ACTIVE_DISCUSSION.md`, `DECISION.md` |
+| Canonical archive vs derived query split | `ROUND_METADATA_INDEX.md` |
+| Near-code bounded memory direction | `round-63-embedded-design-memory.md`, `JJ_VIRTUAL_WORKING_COPIES.md` context |
+| Board linkage without archive takeover | `BOARD_EXECUTION_MODEL.md` and later board items |
+
+So the item should now be read as an accomplished repo-structuring shift, not a
+still-unfinished content migration.
+
+---
+
+## 8. Recommended implementation posture from here
+
+Future work should focus on:
+
+1. better derived indices and browse surfaces
+2. bounded subtree retrieval and projection
+3. explicit lifecycle/supersession for local design-memory records
+4. stronger board linkage to relevant design history
+
+Future work should **not** reopen whether the archive belongs in this repo at
+all. That boundary is already settled.
+
+---
+
+## 9. Final synthesis
+
+The design history is already embedded in `agent-roundtable`.
+
+What matters now is keeping the embedded model disciplined:
+
+- markdown archives remain canonical
+- derived indices remain derived
+- near-code memory remains bounded and supersedable
+- board state links to design history without becoming it
+
+That is the mature closure of item 56.

--- a/docs/work-items/56-embedded-design-merge.md
+++ b/docs/work-items/56-embedded-design-merge.md
@@ -1,17 +1,46 @@
 # 56 — Design History Integration (Embedded Model)
 
-**Status:** `ready`
+**Status:** `done` — **Owner:** `Codex`
 **Tag:** `[structural]`
 
 ## Goal
+
 Merge the design history from `agent-roundtable-design` into the main `agent-roundtable` repository to create a self-documenting product.
 
 ## Scope
+
 - Import all content from `agent-roundtable-design` into `agent-roundtable/docs/design/`.
 - Preserve the history of rounds and decisions.
 - Update `BRIEF.md` and `ACTIVE_DISCUSSION.md` pointers to reflect the new paths.
 - Remove the standalone `agent-roundtable-design` repository after the merge is verified.
 
 ## Acceptance Criteria
+
 - Full design history is accessible within the `agent-roundtable` repo.
 - No loss of information or satisfaction markers during the move.
+
+## Notes
+
+- Primary design sources:
+  - `docs/design/rounds/round-63-embedded-design-memory.md`
+  - `docs/design/ROUND_METADATA_INDEX.md`
+- Closely related work:
+  - `57-agent-task-queue.md`
+  - `63-embedded-design-memory` round conclusions
+  - `79-derived-round-index-and-resource-claims.md`
+
+## Outcome
+
+- Added
+  [docs/design/EMBEDDED_DESIGN_HISTORY_MODEL.md](../design/EMBEDDED_DESIGN_HISTORY_MODEL.md)
+  as the closure note for the embedded design-history model.
+- Recorded that the repo already contains the embedded design corpus under
+  `docs/design/` and that item 56 is no longer about a pending import.
+- Clarified the mature split between:
+  - canonical markdown archives
+  - derived query/index layers
+  - bounded near-code memory projections
+  - board/task linkage
+- Closed the item as a repo-structuring shift that has already been realized,
+  with future work focused on retrieval, supersession, and browse surfaces
+  rather than on a still-pending repository merge.

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -142,7 +142,7 @@ The important rule is action class plus resource class:
 
 ### Workflow & Task Delegation (Round 54)
 
-48. [`56-embedded-design-merge.md`](./56-embedded-design-merge.md) — `ready` — `[structural]` Design History Integration (Embedded Model)
+48. [`56-embedded-design-merge.md`](./56-embedded-design-merge.md) — `done` — **Codex** — `[structural]` Embedded design history model and canonical split
 49. [`57-agent-task-queue.md`](./57-agent-task-queue.md) — `done` — **Codex** — `[structural]` Autonomous agent task queue umbrella and synthesis
 
 ### Board Execution Contracts (Round 70)


### PR DESCRIPTION
## Summary\n- add a closure note for the embedded design-history model now that the design corpus already lives in this repo\n- make the canonical split explicit: markdown archives, derived indices, near-code projections, and board linkage\n- close item 56 as a realized repo-structuring shift rather than a still-pending import\n\n## Testing\n- git diff --check\n