### PR TITLE
feat(prompt): tag-based context pruning (#47)

### DIFF
--- a/docs/work-items/47-tag-based-context-pruning.md
+++ b/docs/work-items/47-tag-based-context-pruning.md
@@ -1,6 +1,6 @@
 # 47 — Tag-Based Context Pruning
 
-**Status:** `ready`
+**Status:** `done`
 
 ## Goal
 Improve token efficiency by pruning agent context windows based on subject tag overlap.

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -124,7 +124,7 @@ The important rule is action class plus resource class:
 36. [`44-provenance-visualization.md`](./44-provenance-visualization.md) — `done` — **GitHub Copilot** — Claim Basis & Provenance Badging
 37. [`45-vouch-anchoring.md`](./45-vouch-anchoring.md) — `done` — **GitHub Copilot** — Human Vouch Anchoring
 38. [`46-dolt-tag-schema.md`](./46-dolt-tag-schema.md) — `done` — **Gemini** — Multidimensional Tagging Schema (Dolt + jj)
-39. [`47-tag-based-context-pruning.md`](./47-tag-based-context-pruning.md) — `ready` — Tag-Based Context Pruning
+39. [`47-tag-based-context-pruning.md`](./47-tag-based-context-pruning.md) — `done` — **Claude Code** — Tag-Based Context Pruning
 40. [`48-prediction-error-heatmap.md`](./48-prediction-error-heatmap.md) — `ready` — Prediction Error Heatmap (System Stress UI)
 
 ### Infrastructure & Operations (Tagged Rounds 48-51)

--- a/roundtable/lib/roundtable/prompt.ex
+++ b/roundtable/lib/roundtable/prompt.ex
@@ -1,12 +1,24 @@
 defmodule Roundtable.Prompt do
   @moduledoc """
   Assembles BRIEF + issue JSON + agent role into a prompt.
+
+  Supports tag-based context pruning: when an issue has subject tags, prior
+  discussion turns are filtered to those with overlapping tags plus any
+  Global Invariant tags (governance, risk) that are never pruned.
   """
+
+  alias Roundtable.Prompt.TagPruner
 
   @doc """
   Builds a prompt for the given agent and question context.
+
+  Options:
+    - `:repo_path` — Dolt repo path; enables tag-based context pruning
+    - `:issue_id` — issue identifier for tag lookup
   """
-  def build(brief_content, issue_data, agent_role) do
+  def build(brief_content, issue_data, agent_role, opts \\ []) do
+    comments_section = build_comments_section(issue_data, opts)
+
     """
     You are participating in a multi-agent roundtable discussion.
 
@@ -21,7 +33,7 @@ defmodule Roundtable.Prompt do
     Body: #{issue_data["body"]}
 
     Comments:
-    #{render_comments(issue_data["comments"])}
+    #{comments_section}
 
     ### Instructions
     1. Read the brief and the current discussion carefully.
@@ -38,6 +50,31 @@ defmodule Roundtable.Prompt do
 
     Your response:
     """
+  end
+
+  defp build_comments_section(issue_data, opts) do
+    repo_path = Keyword.get(opts, :repo_path)
+    issue_id = Keyword.get(opts, :issue_id)
+    comments = issue_data["comments"]
+
+    if repo_path && issue_id && is_list(comments) && comments != [] do
+      turns =
+        Enum.map(comments, fn c ->
+          inferred_tags =
+            TagPruner.infer_tags_from_content(c["body"], repo_path: repo_path)
+
+          %{
+            author: get_in(c, ["author", "login"]) || "unknown",
+            body: c["body"] || "",
+            tags: inferred_tags
+          }
+        end)
+
+      {pruned, _stats} = TagPruner.prune_by_tags(issue_id, turns, repo_path: repo_path)
+      pruned
+    else
+      render_comments(comments)
+    end
   end
 
   defp render_comments(nil), do: "(No comments yet)"

--- a/roundtable/lib/roundtable/prompt/tag_pruner.ex
+++ b/roundtable/lib/roundtable/prompt/tag_pruner.ex
@@ -1,0 +1,145 @@
+defmodule Roundtable.Prompt.TagPruner do
+  @moduledoc """
+  Prunes agent context windows based on subject tag overlap.
+
+  Given the tags on the current question and the full set of prior turns,
+  returns a "Surgical History" containing only turns whose tags overlap
+  with the current topic — plus any turns tagged with Global Invariants
+  (tags that are never pruned regardless of topic).
+  """
+
+  alias Roundtable.Tagging
+  alias Roundtable.Vcs.Dolt
+
+  require Logger
+
+  @global_invariant_kinds ["governance", "risk"]
+
+  @doc """
+  Builds a pruned context string from prior discussion turns, keeping only
+  turns whose tags overlap with the current question's tags.
+
+  Returns `{pruned_context, stats}` where stats contains token efficiency info.
+
+  Options:
+    - `:repo_path` — path to the Dolt repo (required)
+    - `:max_tokens` — approximate token budget for pruned context (default 6000)
+  """
+  def prune_by_tags(issue_id, prior_turns, opts \\ []) do
+    repo_path = Keyword.fetch!(opts, :repo_path)
+    max_chars = Keyword.get(opts, :max_tokens, 6000) * 4
+
+    with {:ok, question_tags} <- Tagging.list_issue_tags(repo_path, issue_id),
+         {:ok, invariant_tags} <- list_invariant_tags(repo_path) do
+      relevant_tags = MapSet.new(question_tags ++ invariant_tags)
+
+      {kept, dropped} =
+        prior_turns
+        |> Enum.split_with(fn turn ->
+          turn_tags = Map.get(turn, :tags, [])
+          turn_is_invariant = Enum.any?(turn_tags, &(&1 in invariant_tags))
+          turn_overlaps = Enum.any?(turn_tags, &MapSet.member?(relevant_tags, &1))
+          turn_is_invariant or turn_overlaps or turn_tags == []
+        end)
+
+      pruned_text =
+        kept
+        |> Enum.map(&format_turn/1)
+        |> Enum.join("\n\n---\n\n")
+        |> String.slice(0, max_chars)
+
+      full_size =
+        prior_turns |> Enum.map(&format_turn/1) |> Enum.join("\n\n---\n\n") |> byte_size()
+
+      pruned_size = byte_size(pruned_text)
+
+      stats = %{
+        total_turns: length(prior_turns),
+        kept_turns: length(kept),
+        dropped_turns: length(dropped),
+        full_bytes: full_size,
+        pruned_bytes: pruned_size,
+        savings_pct:
+          if(full_size > 0,
+            do: Float.round((1 - pruned_size / full_size) * 100, 1),
+            else: 0.0
+          ),
+        question_tags: question_tags,
+        invariant_tags: invariant_tags
+      }
+
+      Logger.info(
+        "[TagPruner] issue=#{issue_id} kept=#{stats.kept_turns}/#{stats.total_turns} " <>
+          "savings=#{stats.savings_pct}% tags=#{inspect(question_tags)}"
+      )
+
+      {pruned_text, stats}
+    else
+      {:error, reason} ->
+        Logger.warning("[TagPruner] falling back to full context: #{inspect(reason)}")
+        full_text = prior_turns |> Enum.map(&format_turn/1) |> Enum.join("\n\n---\n\n")
+
+        stats = %{
+          total_turns: length(prior_turns),
+          kept_turns: length(prior_turns),
+          dropped_turns: 0,
+          full_bytes: byte_size(full_text),
+          pruned_bytes: byte_size(full_text),
+          savings_pct: 0.0,
+          question_tags: [],
+          invariant_tags: []
+        }
+
+        {full_text, stats}
+    end
+  end
+
+  @doc """
+  Extracts tags from a question's title and body by matching `#tag` patterns
+  and known tag IDs from the Dolt tags table.
+
+  This is a lightweight alternative to requiring all questions to be pre-tagged
+  in Dolt — it infers tags from content.
+  """
+  def infer_tags_from_content(text, opts \\ []) do
+    repo_path = Keyword.get(opts, :repo_path)
+
+    explicit =
+      Regex.scan(~r/#([a-z][a-z0-9_-]+)/, text || "")
+      |> Enum.map(fn [_, tag] -> tag end)
+
+    known =
+      if repo_path do
+        case Dolt.query("SELECT id FROM tags", repo_path: repo_path) do
+          {:ok, rows} ->
+            all_tags = Enum.map(rows, & &1["id"])
+            text_lower = String.downcase(text || "")
+            Enum.filter(all_tags, &String.contains?(text_lower, String.downcase(&1)))
+
+          _ ->
+            []
+        end
+      else
+        []
+      end
+
+    (explicit ++ known) |> Enum.uniq()
+  end
+
+  defp list_invariant_tags(repo_path) do
+    kinds = Enum.map_join(@global_invariant_kinds, ", ", &"'#{&1}'")
+    sql = "SELECT id FROM tags WHERE kind IN (#{kinds})"
+
+    case Dolt.query(sql, repo_path: repo_path) do
+      {:ok, rows} -> {:ok, Enum.map(rows, & &1["id"])}
+      {:error, _} -> {:ok, []}
+    end
+  end
+
+  defp format_turn(%{author: author, body: body}) do
+    "**#{author}**:\n#{body}"
+  end
+
+  defp format_turn(%{body: body}), do: body
+  defp format_turn(turn) when is_binary(turn), do: turn
+end

--- a/roundtable/test/roundtable/prompt/tag_pruner_test.exs
+++ b/roundtable/test/roundtable/prompt/tag_pruner_test.exs
@@ -1,0 +1,71 @@
+defmodule Roundtable.Prompt.TagPrunerTest do
+  use ExUnit.Case, async: true
+
+  alias Roundtable.Prompt.TagPruner
+
+  describe "infer_tags_from_content/2" do
+    test "extracts explicit #hashtag patterns" do
+      text = "This is about #networking and #security concerns"
+      assert tags = TagPruner.infer_tags_from_content(text)
+      assert "networking" in tags
+      assert "security" in tags
+    end
+
+    test "ignores uppercase and special characters" do
+      text = "Check #valid-tag but not #123invalid"
+      tags = TagPruner.infer_tags_from_content(text)
+      assert "valid-tag" in tags
+      refute "123invalid" in tags
+    end
+
+    test "returns empty list for nil input" do
+      assert [] == TagPruner.infer_tags_from_content(nil)
+    end
+
+    test "deduplicates tags" do
+      text = "#networking and again #networking"
+      tags = TagPruner.infer_tags_from_content(text)
+      assert length(Enum.filter(tags, &(&1 == "networking"))) == 1
+    end
+  end
+
+  describe "prune_by_tags/3" do
+    test "falls back to full context when Dolt is unavailable" do
+      turns = [
+        %{author: "alice", body: "First point about networking", tags: ["networking"]},
+        %{author: "bob", body: "Second point about security", tags: ["security"]},
+        %{author: "carol", body: "Third about licensing", tags: ["license"]}
+      ]
+
+      {text, stats} = TagPruner.prune_by_tags("issue-1", turns, repo_path: "/nonexistent")
+
+      assert stats.total_turns == 3
+      assert stats.kept_turns == 3
+      assert stats.savings_pct == 0.0
+      assert String.contains?(text, "alice")
+      assert String.contains?(text, "bob")
+      assert String.contains?(text, "carol")
+    end
+
+    test "formats turns with author and body" do
+      turns = [
+        %{author: "alice", body: "Hello world", tags: []},
+        %{body: "No author turn", tags: []}
+      ]
+
+      {text, _stats} = TagPruner.prune_by_tags("issue-1", turns, repo_path: "/nonexistent")
+
+      assert String.contains?(text, "**alice**:")
+      assert String.contains?(text, "Hello world")
+      assert String.contains?(text, "No author turn")
+    end
+
+    test "formats plain string turns" do
+      turns = ["plain text turn"]
+
+      {text, _stats} = TagPruner.prune_by_tags("issue-1", turns, repo_path: "/nonexistent")
+
+      assert String.contains?(text, "plain text turn")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Roundtable.Prompt.TagPruner` module for tag-based context window pruning
- `prune_by_tags/3` filters prior discussion turns to those with overlapping subject tags
- Global Invariant tags (governance, risk kinds) are never pruned regardless of topic
- `infer_tags_from_content/2` extracts `#hashtag` patterns and matches against known Dolt tags
- `Prompt.build/4` accepts optional `:repo_path` and `:issue_id` to enable pruning
- Falls back gracefully to full context when Dolt is unavailable
- Logs token efficiency stats (turns kept/dropped, bytes saved)

## Test plan

- [x] 7 new tests in `tag_pruner_test.exs` covering tag extraction, pruning fallback, and formatting
- [x] Full test suite passes (267+ tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)