### PR TITLE
docs: close prediction error heatmap item

### DIFF
--- a/docs/work-items/48-prediction-error-heatmap.md
+++ b/docs/work-items/48-prediction-error-heatmap.md
@@ -1,6 +1,6 @@
 # 48 — Prediction Error Heatmap (System Stress UI)
 
-**Status:** `in-progress` — **Codex**
+**Status:** `done` — **Owner:** `Codex`
 
 ## Goal
 Replace the linear "Notification List" with a visual heatmap of "System Stress" (Prediction Errors) to focus maintainer attention.
@@ -17,3 +17,31 @@ Replace the linear "Notification List" with a visual heatmap of "System Stress" 
 - Maintainers can see at a glance which modules are "Settled" and which are "Contested."
 - Direct correlation between "Sycophancy Score" (Low Stress/High Redundancy) and "Appraisal Value."
 - Moves the UX from "Managing a Queue" to "Resolving Prediction Errors."
+
+## Outcome
+
+Done in the public Forgejo-shell surface and supporting tests.
+
+The resulting implementation:
+
+- adds a `Project Mind Heatmap` to the public repo demo surface
+- renders `Settled`, `Watch`, and `Contested` heatmap cells
+- includes explicit `Appraisal value` context instead of only abstract stress
+  wording
+- derives heatmap cells from both curated stress hotspots and sampled path
+  hotspots when repo-history evidence is available
+
+Primary implementation path:
+
+- `roundtable/lib/roundtable_web/live/forgejo_shell_live.ex`
+
+Merged in:
+
+- PR `#91`
+
+## Notes
+
+- Closely related work:
+  - `41-integrity-scorecard.md`
+  - `43-red-team-highlights.md`
+  - `68-public-repo-investor-demo.md`

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -125,7 +125,7 @@ The important rule is action class plus resource class:
 37. [`45-vouch-anchoring.md`](./45-vouch-anchoring.md) — `done` — **GitHub Copilot** — Human Vouch Anchoring
 38. [`46-dolt-tag-schema.md`](./46-dolt-tag-schema.md) — `done` — **Gemini** — Multidimensional Tagging Schema (Dolt + jj)
 39. [`47-tag-based-context-pruning.md`](./47-tag-based-context-pruning.md) — `done` — **Claude Code** — Tag-Based Context Pruning
-40. [`48-prediction-error-heatmap.md`](./48-prediction-error-heatmap.md) — `ready` — Prediction Error Heatmap (System Stress UI)
+40. [`48-prediction-error-heatmap.md`](./48-prediction-error-heatmap.md) — `done` — **Codex** — Prediction error heatmap and project-mind stress surface
 
 ### Infrastructure & Operations (Tagged Rounds 48-51)
 


### PR DESCRIPTION
## Summary
- close the stale prediction error heatmap work item
- record the actual public Forgejo-shell implementation outcome
- sync the queue entry from ready to done

## Testing
- git diff --check