### PR TITLE
docs: block slsa attestation hooks on deliberative signing

### DIFF
--- a/docs/work-items/61-slsa-attestation-hooks.md
+++ b/docs/work-items/61-slsa-attestation-hooks.md
@@ -1,6 +1,7 @@
 # 61 — SLSA-Signed Integrity Hooks
 
-**Status:** `ready`
+**Status:** `blocked`
+**Blocked on:** `39-deliberative-slsa.md`
 **Tag:** `[integrity]`
 
 ## Goal
@@ -15,3 +16,27 @@ Harden the supply chain by cryptographically linking code changes to their delib
 ## Acceptance Criteria
 - Backdoor attempts are surfaced as "Unattributed State" in the DAG.
 - 100% provenance visibility from line-of-code back to agent-consensus.
+
+## Notes
+
+- This item is not an independent first move while
+  `39-deliberative-slsa.md` is still in progress.
+- `39` owns the lower signing substrate:
+  - agent key management
+  - signed `jj` / `dolt` deliberation commits
+  - signature-chain validation
+- `61` should resume only after that substrate is stable enough to support:
+  - SLSA-shaped attestation envelopes
+  - commit-to-round binding hooks
+  - a real `vouch-verify` command over already-signed provenance state
+
+## Block reason
+
+The original item assumes an attestation hook layer can be added directly.
+Current queue reality is narrower:
+
+- deliberative signing and provenance validation are already being developed in
+  `39`
+- release/publish authority separation has also moved forward in later items
+- so `61` should be treated as the next integrity layer above those pieces, not
+  as a parallel independent implementation track

--- a/docs/work-items/README.md
+++ b/docs/work-items/README.md
@@ -159,7 +159,7 @@ The important rule is action class plus resource class:
 
 ### Integrity & Scaling (Round 58-59)
 
-56. [`61-slsa-attestation-hooks.md`](./61-slsa-attestation-hooks.md) — `ready` — `[integrity]` SLSA-Signed Integrity Hooks
+56. [`61-slsa-attestation-hooks.md`](./61-slsa-attestation-hooks.md) — `blocked` — `[integrity]` SLSA-Signed Integrity Hooks
 57. [`62-jj-high-velocity-ingest.md`](./62-jj-high-velocity-ingest.md) — `done` — **Codex** — `[structural]` Scalable jj ingestion layer and sieve-first traffic shaping
 
 ### Platform Evolution (JJ + Dolt + Provenance)


### PR DESCRIPTION
## Summary
- mark item 61 blocked on the in-progress deliberative signing item
- explain why the attestation hook layer should not proceed in parallel with the underlying signing substrate
- update the queue so it no longer shows a misleading ready item

## Testing
- git diff --check